### PR TITLE
feat: combine all analysis features into single branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ force-exclude = true
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP"]
+ignore = ["B008"]  # Query() in FastAPI defaults is idiomatic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "sentence-transformers>=3.0.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [dependency-groups]

--- a/sql/002_gravity_views.sql
+++ b/sql/002_gravity_views.sql
@@ -1,0 +1,38 @@
+-- Materialized views for the Geopolitical Gravity Map feature.
+-- These pre-aggregate country co-mention data so the API doesn't
+-- need to cross-join locations on every request.
+--
+-- Refresh periodically:  REFRESH MATERIALIZED VIEW mv_country_comentions;
+--                        REFRESH MATERIALIZED VIEW mv_country_stats;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_country_comentions AS
+SELECT
+    a_loc->>'country_code' AS source_code,
+    b_loc->>'country_code' AS target_code,
+    COUNT(DISTINCT a.id) AS weight
+FROM articles a,
+    jsonb_array_elements(a.locations) AS a_loc,
+    jsonb_array_elements(a.locations) AS b_loc
+WHERE a.locations IS NOT NULL
+  AND jsonb_array_length(a.locations) >= 2
+  AND a_loc->>'country_code' < b_loc->>'country_code'
+  AND a_loc->>'country_code' IS NOT NULL
+  AND b_loc->>'country_code' IS NOT NULL
+GROUP BY 1, 2;
+
+CREATE INDEX IF NOT EXISTS idx_mv_cc_weight ON mv_country_comentions(weight DESC);
+CREATE INDEX IF NOT EXISTS idx_mv_cc_source ON mv_country_comentions(source_code);
+CREATE INDEX IF NOT EXISTS idx_mv_cc_target ON mv_country_comentions(target_code);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_country_stats AS
+SELECT
+    loc->>'country_code' AS code,
+    COUNT(DISTINCT a.id) AS article_count,
+    round(avg((a.tone->>'tone')::float)::numeric, 3) AS avg_tone
+FROM articles a, jsonb_array_elements(a.locations) AS loc
+WHERE a.locations IS NOT NULL
+  AND loc->>'country_code' IS NOT NULL
+  AND a.tone IS NOT NULL
+GROUP BY 1;
+
+CREATE INDEX IF NOT EXISTS idx_mv_cs_code ON mv_country_stats(code);

--- a/src/gdelt_event_pipeline/api/app.py
+++ b/src/gdelt_event_pipeline/api/app.py
@@ -96,7 +96,9 @@ def _ensure_schema() -> None:
                 ")"
             )
             row = cur.fetchone()
-            exists = row[0] if isinstance(row, (tuple, list)) else row.get("exists", False)
+            exists = (
+                row[0] if isinstance(row, (tuple, list)) else row.get("exists", False)
+            )
         if not exists:
             logger.info("Tables not found — running schema initialization...")
             schema_path = Path(__file__).resolve().parents[3] / "sql" / "001_schema.sql"
@@ -168,7 +170,9 @@ async def rate_limit_middleware(request: Request, call_next) -> Response:
 
     # Prune old entries
     timestamps = _rate_limit_store[client_ip]
-    _rate_limit_store[client_ip] = [t for t in timestamps if now - t < RATE_LIMIT_WINDOW]
+    _rate_limit_store[client_ip] = [
+        t for t in timestamps if now - t < RATE_LIMIT_WINDOW
+    ]
 
     if len(_rate_limit_store[client_ip]) >= RATE_LIMIT_MAX:
         return Response(
@@ -236,16 +240,26 @@ def velocity_page():
 def search(
     q: str = Query(..., description="Search query text"),
     limit: int = Query(20, ge=1, le=100, description="Max results"),
-    semantic_weight: float = Query(0.5, ge=0.0, le=1.0, description="Semantic vs keyword weight"),
+    semantic_weight: float = Query(
+        0.5, ge=0.0, le=1.0, description="Semantic vs keyword weight"
+    ),
     clusters: bool = Query(False, description="Also search cluster centroids"),
-    location: str | None = Query(None, description="Filter by location (comma-separated)"),
+    location: str | None = Query(
+        None, description="Filter by location (comma-separated)"
+    ),
     person: str | None = Query(None, description="Filter by person (comma-separated)"),
-    org: str | None = Query(None, description="Filter by organization (comma-separated)"),
+    org: str | None = Query(
+        None, description="Filter by organization (comma-separated)"
+    ),
     theme: str | None = Query(None, description="Filter by theme (comma-separated)"),
     domain: str | None = Query(None, description="Filter by domain (comma-separated)"),
     source: str | None = Query(None, description="Filter by source (comma-separated)"),
-    date_from: datetime | None = Query(None, description="Start date (ISO format)"),  # noqa: B008
-    date_to: datetime | None = Query(None, description="End date (ISO format)"),  # noqa: B008
+    date_from: datetime | None = Query(
+        None, description="Start date (ISO format)"
+    ),  # noqa: B008
+    date_to: datetime | None = Query(
+        None, description="End date (ISO format)"
+    ),  # noqa: B008
 ):
     """Hybrid semantic + keyword search over articles and clusters."""
     filters = SearchFilters(
@@ -258,7 +272,9 @@ def search(
         date_from=date_from,
         date_to=date_to,
     )
-    has_filters = any(getattr(filters, f) is not None for f in filters.__dataclass_fields__)
+    has_filters = any(
+        getattr(filters, f) is not None for f in filters.__dataclass_fields__
+    )
 
     request = SearchRequest(
         query=q,
@@ -306,11 +322,15 @@ def get_stats():
             total_articles = cur.fetchone()["cnt"]
             cur.execute("SELECT count(*) AS cnt FROM articles WHERE title IS NOT NULL")
             titled = cur.fetchone()["cnt"]
-            cur.execute("SELECT count(*) AS cnt FROM articles WHERE embedding IS NOT NULL")
+            cur.execute(
+                "SELECT count(*) AS cnt FROM articles WHERE embedding IS NOT NULL"
+            )
             embedded = cur.fetchone()["cnt"]
             cur.execute("SELECT count(*) AS cnt FROM clusters WHERE is_active = true")
             total_clusters = cur.fetchone()["cnt"]
-            cur.execute("SELECT max(article_count) AS val FROM clusters WHERE is_active = true")
+            cur.execute(
+                "SELECT max(article_count) AS val FROM clusters WHERE is_active = true"
+            )
             largest_cluster = cur.fetchone()["val"] or 0
             cur.execute("SELECT count(*) AS cnt FROM cluster_memberships")
             total_memberships = cur.fetchone()["cnt"]
@@ -337,14 +357,22 @@ def list_articles(
 def list_clusters(
     limit: int = Query(100, ge=1, le=500, description="Max clusters to return"),
     sort: str = Query("recent", description="Sort: recent, articles, oldest"),
-    location: str | None = Query(None, description="Filter by location (comma-separated)"),
+    location: str | None = Query(
+        None, description="Filter by location (comma-separated)"
+    ),
     person: str | None = Query(None, description="Filter by person (comma-separated)"),
-    org: str | None = Query(None, description="Filter by organization (comma-separated)"),
+    org: str | None = Query(
+        None, description="Filter by organization (comma-separated)"
+    ),
     theme: str | None = Query(None, description="Filter by theme (comma-separated)"),
     domain: str | None = Query(None, description="Filter by domain (comma-separated)"),
     source: str | None = Query(None, description="Filter by source (comma-separated)"),
-    date_from: datetime | None = Query(None, description="Start date (ISO format)"),  # noqa: B008
-    date_to: datetime | None = Query(None, description="End date (ISO format)"),  # noqa: B008
+    date_from: datetime | None = Query(
+        None, description="Start date (ISO format)"
+    ),  # noqa: B008
+    date_to: datetime | None = Query(
+        None, description="End date (ISO format)"
+    ),  # noqa: B008
 ):
     """List active clusters, optionally filtered by article metadata."""
     locations = _split_csv(location)
@@ -355,7 +383,16 @@ def list_clusters(
     sources = _split_csv(source)
 
     has_filters = any(
-        [locations, persons, organizations, themes, domains, sources, date_from, date_to]
+        [
+            locations,
+            persons,
+            organizations,
+            themes,
+            domains,
+            sources,
+            date_from,
+            date_to,
+        ]
     )
 
     if not has_filters:
@@ -388,7 +425,9 @@ def list_clusters(
         article_conditions.append("a.domain ILIKE %s")
         params.append(f"%{domains[0]}%")
     if sources:
-        article_conditions.append("(a.source_common_name ILIKE %s OR a.canonical_source ILIKE %s)")
+        article_conditions.append(
+            "(a.source_common_name ILIKE %s OR a.canonical_source ILIKE %s)"
+        )
         params.extend([f"%{sources[0]}%", f"%{sources[0]}%"])
     if date_from:
         article_conditions.append("a.gdelt_timestamp >= %s")
@@ -651,7 +690,9 @@ def globe_clusters(
                 "article_count": c["article_count"],
                 "recent_count": c.get("recent_count", 0),
                 "velocity": round(c.get("velocity", 0), 3),
-                "silent_hours": round(c["silent_hours"], 1) if c.get("silent_hours") else None,
+                "silent_hours": (
+                    round(c["silent_hours"], 1) if c.get("silent_hours") else None
+                ),
                 "age_hours": round(c["age_hours"], 1) if c.get("age_hours") else None,
                 "lat": lat,
                 "lon": lon,
@@ -825,7 +866,9 @@ def _categorize_themes(themes: list[str]) -> str:
 @app.get("/api/polarization")
 def get_polarization(
     limit: int = Query(30, ge=1, le=100, description="Max clusters to return"),
-    min_articles: int = Query(20, ge=5, le=500, description="Minimum articles per cluster"),
+    min_articles: int = Query(
+        20, ge=5, le=500, description="Minimum articles per cluster"
+    ),
 ):
     """Return the most narratively polarized story clusters.
 
@@ -1020,13 +1063,19 @@ def get_polarization_detail(cluster_id: str):
                 "domain": a["domain"],
                 "gdelt_timestamp": a["gdelt_timestamp"],
                 "tone": round(a["tone"], 3) if a["tone"] is not None else None,
-                "polarity": round(a["polarity"], 3) if a["polarity"] is not None else None,
-                "positive_score": round(a["positive_score"], 3)
-                if a["positive_score"] is not None
-                else None,
-                "negative_score": round(a["negative_score"], 3)
-                if a["negative_score"] is not None
-                else None,
+                "polarity": (
+                    round(a["polarity"], 3) if a["polarity"] is not None else None
+                ),
+                "positive_score": (
+                    round(a["positive_score"], 3)
+                    if a["positive_score"] is not None
+                    else None
+                ),
+                "negative_score": (
+                    round(a["negative_score"], 3)
+                    if a["negative_score"] is not None
+                    else None
+                ),
             }
         )
 
@@ -1048,7 +1097,9 @@ def get_polarization_detail(cluster_id: str):
     # Overall stats
     all_tones = [a["tone"] for a in articles if a["tone"] is not None]
     avg = sum(all_tones) / len(all_tones) if all_tones else 0
-    variance = sum((t - avg) ** 2 for t in all_tones) / len(all_tones) if all_tones else 0
+    variance = (
+        sum((t - avg) ** 2 for t in all_tones) / len(all_tones) if all_tones else 0
+    )
     stddev = variance**0.5
 
     return {
@@ -1084,8 +1135,7 @@ def get_asymmetry():
 
         with conn.cursor(row_factory=dict_row) as cur:
             # Coverage volume per country
-            cur.execute(
-                """
+            cur.execute("""
                 SELECT
                     loc->>'country_code' AS code,
                     COUNT(DISTINCT a.id) AS article_count,
@@ -1096,14 +1146,12 @@ def get_asymmetry():
                   AND a.tone IS NOT NULL
                 GROUP BY 1
                 ORDER BY 2 DESC
-                """
-            )
+                """)
             countries = cur.fetchall()
 
             # Crisis-tagged articles per country (themes indicating conflict,
             # disaster, or humanitarian issues)
-            cur.execute(
-                """
+            cur.execute("""
                 SELECT
                     loc->>'country_code' AS code,
                     COUNT(DISTINCT a.id) AS crisis_articles
@@ -1126,27 +1174,23 @@ def get_asymmetry():
                     OR theme->>'theme' ILIKE '%%WOUND%%'
                   )
                 GROUP BY 1
-                """
-            )
+                """)
             crisis_rows = cur.fetchall()
 
             # Top overcovered clusters (most articles, any country)
-            cur.execute(
-                """
+            cur.execute("""
                 SELECT id, representative_title, article_count,
                        first_article_at, last_article_at
                 FROM clusters
                 WHERE is_active = true
                 ORDER BY article_count DESC
                 LIMIT 10
-                """
-            )
+                """)
             overcovered = cur.fetchall()
 
             # Underreported: clusters where MOST articles are crisis-tagged
             # but total coverage is low
-            cur.execute(
-                """
+            cur.execute("""
                 SELECT c.id, c.representative_title, c.article_count,
                        c.first_article_at, c.last_article_at,
                        crisis.crisis_count,
@@ -1175,8 +1219,7 @@ def get_asymmetry():
                   AND crisis.crisis_count::float / c.article_count >= 0.6
                 ORDER BY crisis.crisis_count DESC, c.article_count ASC
                 LIMIT 20
-                """
-            )
+                """)
             underreported = cur.fetchall()
 
     # Build crisis map
@@ -1192,13 +1235,17 @@ def get_asymmetry():
             {
                 "code": c["code"],
                 "article_count": c["article_count"],
-                "coverage_pct": round(c["article_count"] / total_articles * 100, 3)
-                if total_articles
-                else 0,
+                "coverage_pct": (
+                    round(c["article_count"] / total_articles * 100, 3)
+                    if total_articles
+                    else 0
+                ),
                 "crisis_articles": crisis_count,
-                "crisis_ratio": round(crisis_count / c["article_count"], 3)
-                if c["article_count"]
-                else 0,
+                "crisis_ratio": (
+                    round(crisis_count / c["article_count"], 3)
+                    if c["article_count"]
+                    else 0
+                ),
                 "avg_tone": float(c["avg_tone"]) if c["avg_tone"] is not None else 0,
             }
         )
@@ -1235,7 +1282,9 @@ def get_asymmetry():
 
 @app.get("/api/gravity/graph")
 def gravity_graph(
-    min_weight: int = Query(50, ge=10, le=5000, description="Minimum co-mention count for edges"),
+    min_weight: int = Query(
+        50, ge=10, le=5000, description="Minimum co-mention count for edges"
+    ),
     limit_edges: int = Query(80, ge=10, le=300, description="Max edges to return"),
 ):
     """Return country co-mention graph for the geopolitical gravity map.
@@ -1367,8 +1416,7 @@ def gravity_country_detail(code: str):
         "article_count": stats["article_count"],
         "avg_tone": float(stats["avg_tone"]) if stats["avg_tone"] is not None else 0,
         "connections": [
-            {"code": c["connected_code"], "weight": c["weight"]}
-            for c in connections
+            {"code": c["connected_code"], "weight": c["weight"]} for c in connections
         ],
         "top_clusters": [
             {
@@ -1390,8 +1438,12 @@ def gravity_country_detail(code: str):
 @app.get("/api/sources/fingerprints")
 def source_fingerprints(
     limit: int = Query(50, ge=1, le=200, description="Max sources to return"),
-    sort: str = Query("articles", description="Sort: articles, tone_positive, tone_negative"),
-    min_articles: int = Query(10, ge=1, description="Minimum articles to include source"),
+    sort: str = Query(
+        "articles", description="Sort: articles, tone_positive, tone_negative"
+    ),
+    min_articles: int = Query(
+        10, ge=1, description="Minimum articles to include source"
+    ),
 ):
     """Per-source fingerprints: article count, avg tone, top themes, top countries."""
     from gdelt_event_pipeline.storage.database import get_pool
@@ -1647,10 +1699,16 @@ def source_detail(domain: str):
         "first_article": stats["first_article"],
         "last_article": stats["last_article"],
         "themes": [
-            {"theme": t["theme"], "count": t["cnt"], "category": _categorize_themes([t["theme"]])}
+            {
+                "theme": t["theme"],
+                "count": t["cnt"],
+                "category": _categorize_themes([t["theme"]]),
+            }
             for t in themes
         ],
-        "countries": [{"country_code": c["country_code"], "count": c["cnt"]} for c in countries],
+        "countries": [
+            {"country_code": c["country_code"], "count": c["cnt"]} for c in countries
+        ],
         "categories": categories,
         "tone_timeline": [
             {
@@ -1782,7 +1840,9 @@ def propagation_timeline(cluster_id: str):
                 "domain": domain,
                 "source_name": a["source_name"],
                 "timestamp": a["gdelt_timestamp"],
-                "tone": round(a["tone_score"], 2) if a["tone_score"] is not None else None,
+                "tone": (
+                    round(a["tone_score"], 2) if a["tone_score"] is not None else None
+                ),
                 "location": loc_name,
                 "is_first_from_source": is_first,
                 "order": i,
@@ -1821,7 +1881,9 @@ def propagation_timeline(cluster_id: str):
             hour = int((ts - first_ts).total_seconds() / 3600)
             hourly[hour] += 1
         max_hour = max(hourly.keys()) if hourly else 0
-        histogram = [{"hour": h, "count": hourly.get(h, 0)} for h in range(max_hour + 1)]
+        histogram = [
+            {"hour": h, "count": hourly.get(h, 0)} for h in range(max_hour + 1)
+        ]
     else:
         histogram = []
 
@@ -1987,7 +2049,6 @@ def velocity_timeline(
     }
 
 
-
 # ── Runner ────────────────────────────────────────────────────────────
 
 
@@ -1995,7 +2056,9 @@ def run() -> None:
     """Convenience entry point: uvicorn gdelt_event_pipeline.api.app:app"""
     import uvicorn
 
-    uvicorn.run("gdelt_event_pipeline.api.app:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run(
+        "gdelt_event_pipeline.api.app:app", host="0.0.0.0", port=8000, reload=True
+    )
 
 
 if __name__ == "__main__":

--- a/src/gdelt_event_pipeline/api/app.py
+++ b/src/gdelt_event_pipeline/api/app.py
@@ -154,6 +154,12 @@ async def rate_limit_middleware(request: Request, call_next) -> Response:
         request.url.path.startswith("/api/search")
         or request.url.path.startswith("/api/clusters")
         or request.url.path.startswith("/api/globe")
+        or request.url.path.startswith("/api/polarization")
+        or request.url.path.startswith("/api/gravity")
+        or request.url.path.startswith("/api/asymmetry")
+        or request.url.path.startswith("/api/sources")
+        or request.url.path.startswith("/api/propagation")
+        or request.url.path.startswith("/api/velocity")
     ):
         return await call_next(request)
 
@@ -185,6 +191,42 @@ def root():
 def globe():
     """Serve the NewsGlobe frontend."""
     return FileResponse(STATIC_DIR / "globe.html")
+
+
+@app.get("/polarization", include_in_schema=False)
+def polarization_page():
+    """Serve the Narrative Polarization frontend."""
+    return FileResponse(STATIC_DIR / "polarization.html")
+
+
+@app.get("/gravity", include_in_schema=False)
+def gravity_page():
+    """Serve the Geopolitical Gravity Map frontend."""
+    return FileResponse(STATIC_DIR / "gravity.html")
+
+
+@app.get("/asymmetry", include_in_schema=False)
+def asymmetry_page():
+    """Serve the Attention Asymmetry frontend."""
+    return FileResponse(STATIC_DIR / "asymmetry.html")
+
+
+@app.get("/sources", include_in_schema=False)
+def sources_page():
+    """Serve the Source DNA frontend."""
+    return FileResponse(STATIC_DIR / "sources.html")
+
+
+@app.get("/propagation", include_in_schema=False)
+def propagation_page():
+    """Serve the Story Propagation frontend."""
+    return FileResponse(STATIC_DIR / "propagation.html")
+
+
+@app.get("/velocity", include_in_schema=False)
+def velocity_page():
+    """Serve the Topic Velocity frontend."""
+    return FileResponse(STATIC_DIR / "velocity.html")
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────
@@ -775,6 +817,1175 @@ def _categorize_themes(themes: list[str]) -> str:
     ):
         return "society"
     return "general"
+
+
+# ── Polarization endpoints ───────────────────────────────
+
+
+@app.get("/api/polarization")
+def get_polarization(
+    limit: int = Query(30, ge=1, le=100, description="Max clusters to return"),
+    min_articles: int = Query(20, ge=5, le=500, description="Minimum articles per cluster"),
+):
+    """Return the most narratively polarized story clusters.
+
+    Polarization score = standard deviation of tone across articles
+    within the same cluster.  High stddev means the same story is
+    being framed very differently by different sources.
+    """
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT
+                    c.id,
+                    c.representative_title,
+                    c.article_count,
+                    c.first_article_at,
+                    c.last_article_at,
+                    round(avg((a.tone->>'tone')::float)::numeric, 3)     AS avg_tone,
+                    round(stddev((a.tone->>'tone')::float)::numeric, 3)  AS tone_stddev,
+                    round(min((a.tone->>'tone')::float)::numeric, 3)     AS tone_min,
+                    round(max((a.tone->>'tone')::float)::numeric, 3)     AS tone_max,
+                    count(DISTINCT a.domain)                              AS distinct_sources
+                FROM clusters c
+                JOIN cluster_memberships cm ON cm.cluster_id = c.id
+                JOIN articles a ON a.id = cm.article_id
+                WHERE c.is_active = true
+                  AND c.article_count >= %s
+                  AND a.tone IS NOT NULL
+                GROUP BY c.id
+                HAVING count(*) >= %s AND stddev((a.tone->>'tone')::float) IS NOT NULL
+                ORDER BY tone_stddev DESC
+                LIMIT %s
+                """,
+                (min_articles, min_articles, limit),
+            )
+            clusters = cur.fetchall()
+
+            if not clusters:
+                return []
+
+            cluster_ids = [c["id"] for c in clusters]
+
+            # Per-source tone breakdown for each cluster
+            cur.execute(
+                """
+                SELECT
+                    cm.cluster_id,
+                    COALESCE(a.canonical_source, a.domain) AS source,
+                    round(avg((a.tone->>'tone')::float)::numeric, 3) AS avg_tone,
+                    count(*) AS article_count
+                FROM cluster_memberships cm
+                JOIN articles a ON a.id = cm.article_id
+                WHERE cm.cluster_id = ANY(%s)
+                  AND a.tone IS NOT NULL
+                GROUP BY cm.cluster_id, COALESCE(a.canonical_source, a.domain)
+                HAVING count(*) >= 2
+                ORDER BY cm.cluster_id, avg((a.tone->>'tone')::float) ASC
+                """,
+                (cluster_ids,),
+            )
+            source_rows = cur.fetchall()
+
+            # Tone histogram buckets per cluster
+            cur.execute(
+                """
+                SELECT
+                    cm.cluster_id,
+                    width_bucket((a.tone->>'tone')::float, -10, 10, 20) AS bucket,
+                    count(*) AS cnt
+                FROM cluster_memberships cm
+                JOIN articles a ON a.id = cm.article_id
+                WHERE cm.cluster_id = ANY(%s)
+                  AND a.tone IS NOT NULL
+                GROUP BY cm.cluster_id, bucket
+                ORDER BY cm.cluster_id, bucket
+                """,
+                (cluster_ids,),
+            )
+            hist_rows = cur.fetchall()
+
+    # Build per-cluster source breakdown
+    sources_by_cluster: dict[str, list[dict]] = defaultdict(list)
+    for row in source_rows:
+        cid = str(row["cluster_id"])
+        sources_by_cluster[cid].append(
+            {
+                "source": row["source"],
+                "avg_tone": float(row["avg_tone"]),
+                "article_count": row["article_count"],
+            }
+        )
+
+    # Build per-cluster histogram
+    hist_by_cluster: dict[str, list[dict]] = defaultdict(list)
+    for row in hist_rows:
+        cid = str(row["cluster_id"])
+        bucket_idx = row["bucket"]
+        # width_bucket(val, -10, 10, 20) → buckets 1..20, each 1.0 wide
+        low = -10 + (bucket_idx - 1) * 1.0
+        hist_by_cluster[cid].append(
+            {
+                "range_low": low,
+                "range_high": low + 1.0,
+                "count": row["cnt"],
+            }
+        )
+
+    results = []
+    for c in clusters:
+        cid = str(c["id"])
+        sources = sources_by_cluster.get(cid, [])
+        histogram = hist_by_cluster.get(cid, [])
+
+        results.append(
+            {
+                "id": cid,
+                "title": c["representative_title"],
+                "article_count": c["article_count"],
+                "first_article_at": c["first_article_at"],
+                "last_article_at": c["last_article_at"],
+                "polarization_score": float(c["tone_stddev"]),
+                "avg_tone": float(c["avg_tone"]),
+                "tone_min": float(c["tone_min"]),
+                "tone_max": float(c["tone_max"]),
+                "distinct_sources": c["distinct_sources"],
+                "sources": sources[:15],  # top 15 sources
+                "histogram": histogram,
+            }
+        )
+
+    return results
+
+
+@app.get("/api/polarization/{cluster_id}")
+def get_polarization_detail(cluster_id: str):
+    """Detailed polarization breakdown for a single cluster.
+
+    Returns every article with its tone, grouped by source.
+    """
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT id, representative_title, article_count, "
+                "first_article_at, last_article_at FROM clusters WHERE id = %s",
+                (cluster_id,),
+            )
+            cluster = cur.fetchone()
+            if not cluster:
+                raise HTTPException(status_code=404, detail="Cluster not found")
+
+            cur.execute(
+                """
+                SELECT
+                    a.id,
+                    a.title,
+                    a.url,
+                    a.canonical_url,
+                    a.domain,
+                    COALESCE(a.canonical_source, a.domain) AS source,
+                    a.gdelt_timestamp,
+                    (a.tone->>'tone')::float AS tone,
+                    (a.tone->>'polarity')::float AS polarity,
+                    (a.tone->>'positive_score')::float AS positive_score,
+                    (a.tone->>'negative_score')::float AS negative_score
+                FROM cluster_memberships cm
+                JOIN articles a ON a.id = cm.article_id
+                WHERE cm.cluster_id = %s
+                  AND a.tone IS NOT NULL
+                ORDER BY (a.tone->>'tone')::float ASC
+                """,
+                (cluster_id,),
+            )
+            articles = cur.fetchall()
+
+    # Group by source
+    source_groups: dict[str, list[dict]] = defaultdict(list)
+    for a in articles:
+        source_groups[a["source"]].append(
+            {
+                "title": a["title"],
+                "url": a["canonical_url"] or a["url"],
+                "domain": a["domain"],
+                "gdelt_timestamp": a["gdelt_timestamp"],
+                "tone": round(a["tone"], 3) if a["tone"] is not None else None,
+                "polarity": round(a["polarity"], 3) if a["polarity"] is not None else None,
+                "positive_score": round(a["positive_score"], 3)
+                if a["positive_score"] is not None
+                else None,
+                "negative_score": round(a["negative_score"], 3)
+                if a["negative_score"] is not None
+                else None,
+            }
+        )
+
+    # Sort sources by average tone
+    source_summaries = []
+    for source, arts in source_groups.items():
+        tones = [a["tone"] for a in arts if a["tone"] is not None]
+        avg_t = sum(tones) / len(tones) if tones else 0
+        source_summaries.append(
+            {
+                "source": source,
+                "avg_tone": round(avg_t, 3),
+                "article_count": len(arts),
+                "articles": arts,
+            }
+        )
+    source_summaries.sort(key=lambda x: x["avg_tone"])
+
+    # Overall stats
+    all_tones = [a["tone"] for a in articles if a["tone"] is not None]
+    avg = sum(all_tones) / len(all_tones) if all_tones else 0
+    variance = sum((t - avg) ** 2 for t in all_tones) / len(all_tones) if all_tones else 0
+    stddev = variance**0.5
+
+    return {
+        "cluster": {
+            "id": str(cluster["id"]),
+            "title": cluster["representative_title"],
+            "article_count": cluster["article_count"],
+            "first_article_at": cluster["first_article_at"],
+            "last_article_at": cluster["last_article_at"],
+        },
+        "polarization_score": round(stddev, 3),
+        "avg_tone": round(avg, 3),
+        "tone_min": round(min(all_tones), 3) if all_tones else 0,
+        "tone_max": round(max(all_tones), 3) if all_tones else 0,
+        "total_articles_with_tone": len(all_tones),
+        "sources": source_summaries,
+    }
+
+
+# ── Attention Asymmetry endpoints ─────────────────────────────────────
+
+
+@app.get("/api/asymmetry")
+def get_asymmetry():
+    """Return attention asymmetry data: coverage by country vs crisis
+    theme intensity, revealing overcovered and underreported regions.
+    """
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            # Coverage volume per country
+            cur.execute(
+                """
+                SELECT
+                    loc->>'country_code' AS code,
+                    COUNT(DISTINCT a.id) AS article_count,
+                    round(avg((a.tone->>'tone')::float)::numeric, 3) AS avg_tone
+                FROM articles a, jsonb_array_elements(a.locations) AS loc
+                WHERE a.locations IS NOT NULL
+                  AND loc->>'country_code' IS NOT NULL
+                  AND a.tone IS NOT NULL
+                GROUP BY 1
+                ORDER BY 2 DESC
+                """
+            )
+            countries = cur.fetchall()
+
+            # Crisis-tagged articles per country (themes indicating conflict,
+            # disaster, or humanitarian issues)
+            cur.execute(
+                """
+                SELECT
+                    loc->>'country_code' AS code,
+                    COUNT(DISTINCT a.id) AS crisis_articles
+                FROM articles a,
+                    jsonb_array_elements(a.locations) AS loc,
+                    jsonb_array_elements(a.themes) AS theme
+                WHERE a.locations IS NOT NULL
+                  AND a.themes IS NOT NULL
+                  AND loc->>'country_code' IS NOT NULL
+                  AND (
+                    theme->>'theme' ILIKE '%%CONFLICT%%'
+                    OR theme->>'theme' ILIKE '%%CRISIS%%'
+                    OR theme->>'theme' ILIKE '%%DISASTER%%'
+                    OR theme->>'theme' ILIKE '%%KILL%%'
+                    OR theme->>'theme' ILIKE '%%TERROR%%'
+                    OR theme->>'theme' ILIKE '%%ARMED%%'
+                    OR theme->>'theme' ILIKE '%%WAR%%'
+                    OR theme->>'theme' ILIKE '%%REFUGEE%%'
+                    OR theme->>'theme' ILIKE '%%FAMINE%%'
+                    OR theme->>'theme' ILIKE '%%WOUND%%'
+                  )
+                GROUP BY 1
+                """
+            )
+            crisis_rows = cur.fetchall()
+
+            # Top overcovered clusters (most articles, any country)
+            cur.execute(
+                """
+                SELECT id, representative_title, article_count,
+                       first_article_at, last_article_at
+                FROM clusters
+                WHERE is_active = true
+                ORDER BY article_count DESC
+                LIMIT 10
+                """
+            )
+            overcovered = cur.fetchall()
+
+            # Underreported: clusters where MOST articles are crisis-tagged
+            # but total coverage is low
+            cur.execute(
+                """
+                SELECT c.id, c.representative_title, c.article_count,
+                       c.first_article_at, c.last_article_at,
+                       crisis.crisis_count,
+                       round(crisis.crisis_count::numeric / c.article_count, 2) AS crisis_pct
+                FROM clusters c
+                JOIN (
+                    SELECT cm.cluster_id, COUNT(DISTINCT a.id) AS crisis_count
+                    FROM cluster_memberships cm
+                    JOIN articles a ON a.id = cm.article_id,
+                        jsonb_array_elements(a.themes) AS theme
+                    WHERE a.themes IS NOT NULL
+                      AND (
+                        theme->>'theme' ILIKE '%%CONFLICT%%'
+                        OR theme->>'theme' ILIKE '%%KILL%%'
+                        OR theme->>'theme' ILIKE '%%TERROR%%'
+                        OR theme->>'theme' ILIKE '%%ARMED%%'
+                        OR theme->>'theme' ILIKE '%%REFUGEE%%'
+                        OR theme->>'theme' ILIKE '%%FAMINE%%'
+                        OR theme->>'theme' ILIKE '%%WOUND%%'
+                      )
+                    GROUP BY cm.cluster_id
+                    HAVING COUNT(DISTINCT a.id) >= 3
+                ) crisis ON crisis.cluster_id = c.id
+                WHERE c.is_active = true
+                  AND c.article_count BETWEEN 5 AND 40
+                  AND crisis.crisis_count::float / c.article_count >= 0.6
+                ORDER BY crisis.crisis_count DESC, c.article_count ASC
+                LIMIT 20
+                """
+            )
+            underreported = cur.fetchall()
+
+    # Build crisis map
+    crisis_map = {r["code"]: r["crisis_articles"] for r in crisis_rows}
+
+    # Total articles for percentage calculation
+    total_articles = sum(c["article_count"] for c in countries)
+
+    country_data = []
+    for c in countries:
+        crisis_count = crisis_map.get(c["code"], 0)
+        country_data.append(
+            {
+                "code": c["code"],
+                "article_count": c["article_count"],
+                "coverage_pct": round(c["article_count"] / total_articles * 100, 3)
+                if total_articles
+                else 0,
+                "crisis_articles": crisis_count,
+                "crisis_ratio": round(crisis_count / c["article_count"], 3)
+                if c["article_count"]
+                else 0,
+                "avg_tone": float(c["avg_tone"]) if c["avg_tone"] is not None else 0,
+            }
+        )
+
+    return {
+        "total_articles": total_articles,
+        "total_countries": len(countries),
+        "countries": country_data,
+        "overcovered": [
+            {
+                "id": str(c["id"]),
+                "title": c["representative_title"],
+                "article_count": c["article_count"],
+                "first_article_at": c["first_article_at"],
+                "last_article_at": c["last_article_at"],
+            }
+            for c in overcovered
+        ],
+        "underreported": [
+            {
+                "id": str(c["id"]),
+                "title": c["representative_title"],
+                "article_count": c["article_count"],
+                "first_article_at": c["first_article_at"],
+                "last_article_at": c["last_article_at"],
+            }
+            for c in underreported
+        ],
+    }
+
+
+# ── Gravity Map endpoints ────────────────────────────────
+
+
+@app.get("/api/gravity/graph")
+def gravity_graph(
+    min_weight: int = Query(50, ge=10, le=5000, description="Minimum co-mention count for edges"),
+    limit_edges: int = Query(80, ge=10, le=300, description="Max edges to return"),
+):
+    """Return country co-mention graph for the geopolitical gravity map.
+
+    Nodes = countries (with article counts and avg tone).
+    Edges = co-mention relationships (with weight = co-mention count).
+    """
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            # Edges from materialized view
+            cur.execute(
+                """
+                SELECT source_code AS source, target_code AS target, weight
+                FROM mv_country_comentions
+                WHERE weight >= %s
+                ORDER BY weight DESC
+                LIMIT %s
+                """,
+                (min_weight, limit_edges),
+            )
+            edges = cur.fetchall()
+
+            # Collect all country codes that appear in edges
+            codes = set()
+            for e in edges:
+                codes.add(e["source"])
+                codes.add(e["target"])
+
+            if not codes:
+                return {"nodes": [], "edges": []}
+
+            # Nodes from materialized view
+            code_list = list(codes)
+            cur.execute(
+                """
+                SELECT code, article_count, avg_tone
+                FROM mv_country_stats
+                WHERE code = ANY(%s)
+                """,
+                (code_list,),
+            )
+            node_rows = cur.fetchall()
+
+    nodes = [
+        {
+            "id": n["code"],
+            "article_count": n["article_count"],
+            "avg_tone": float(n["avg_tone"]) if n["avg_tone"] is not None else 0,
+        }
+        for n in node_rows
+    ]
+
+    edge_list = [
+        {
+            "source": e["source"],
+            "target": e["target"],
+            "weight": e["weight"],
+        }
+        for e in edges
+    ]
+
+    return {"nodes": nodes, "edges": edge_list}
+
+
+@app.get("/api/gravity/country/{code}")
+def gravity_country_detail(code: str):
+    """Detail view for a single country: top connected countries,
+    top clusters, and tone breakdown."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            # Country stats from materialized view
+            cur.execute(
+                "SELECT code, article_count, avg_tone FROM mv_country_stats WHERE code = %s",
+                (code,),
+            )
+            stats = cur.fetchone()
+            if not stats or stats["article_count"] == 0:
+                raise HTTPException(status_code=404, detail="Country not found")
+
+            # Top connected countries from materialized view
+            cur.execute(
+                """
+                SELECT
+                    CASE WHEN source_code = %s THEN target_code ELSE source_code END
+                        AS connected_code,
+                    weight
+                FROM mv_country_comentions
+                WHERE source_code = %s OR target_code = %s
+                ORDER BY weight DESC
+                LIMIT 15
+                """,
+                (code, code, code),
+            )
+            connections = cur.fetchall()
+
+            # Top clusters mentioning this country
+            cur.execute(
+                """
+                SELECT c.id, c.representative_title, c.article_count,
+                       c.first_article_at, c.last_article_at,
+                       COUNT(*) AS mentions
+                FROM clusters c
+                JOIN cluster_memberships cm ON cm.cluster_id = c.id
+                JOIN articles a ON a.id = cm.article_id,
+                    jsonb_array_elements(a.locations) AS loc
+                WHERE a.locations IS NOT NULL
+                  AND loc->>'country_code' = %s
+                  AND c.is_active = true
+                GROUP BY c.id
+                ORDER BY mentions DESC
+                LIMIT 10
+                """,
+                (code,),
+            )
+            top_clusters = cur.fetchall()
+
+    return {
+        "code": code,
+        "article_count": stats["article_count"],
+        "avg_tone": float(stats["avg_tone"]) if stats["avg_tone"] is not None else 0,
+        "connections": [
+            {"code": c["connected_code"], "weight": c["weight"]}
+            for c in connections
+        ],
+        "top_clusters": [
+            {
+                "id": str(c["id"]),
+                "title": c["representative_title"],
+                "article_count": c["article_count"],
+                "mentions": c["mentions"],
+                "first_article_at": c["first_article_at"],
+                "last_article_at": c["last_article_at"],
+            }
+            for c in top_clusters
+        ],
+    }
+
+
+# ── Source DNA endpoints ─────────────────────────────────────────────
+
+
+@app.get("/api/sources/fingerprints")
+def source_fingerprints(
+    limit: int = Query(50, ge=1, le=200, description="Max sources to return"),
+    sort: str = Query("articles", description="Sort: articles, tone_positive, tone_negative"),
+    min_articles: int = Query(10, ge=1, description="Minimum articles to include source"),
+):
+    """Per-source fingerprints: article count, avg tone, top themes, top countries."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    order_clause = {
+        "tone_positive": "avg_tone DESC",
+        "tone_negative": "avg_tone ASC",
+    }.get(sort, "article_count DESC")
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT
+                    COALESCE(source_common_name, domain) AS source_name,
+                    domain,
+                    count(*) AS article_count,
+                    avg((tone->>'tone')::float) FILTER (WHERE tone->>'tone' IS NOT NULL)
+                        AS avg_tone,
+                    avg((tone->>'positive_score')::float)
+                        FILTER (WHERE tone->>'positive_score' IS NOT NULL) AS avg_positive,
+                    avg((tone->>'negative_score')::float)
+                        FILTER (WHERE tone->>'negative_score' IS NOT NULL) AS avg_negative,
+                    avg((tone->>'polarity')::float)
+                        FILTER (WHERE tone->>'polarity' IS NOT NULL) AS avg_polarity,
+                    min(gdelt_timestamp) AS first_article,
+                    max(gdelt_timestamp) AS last_article
+                FROM articles
+                WHERE title IS NOT NULL
+                GROUP BY COALESCE(source_common_name, domain), domain
+                HAVING count(*) >= %s
+                ORDER BY {order_clause}
+                LIMIT %s
+                """,
+                (min_articles, limit),
+            )
+            sources = cur.fetchall()
+
+            if not sources:
+                return []
+
+            # Get top themes per source (top 8)
+            source_domains = [s["domain"] for s in sources]
+            cur.execute(
+                """
+                SELECT domain,
+                       t->>'theme' AS theme,
+                       count(*) AS cnt
+                FROM articles,
+                     jsonb_array_elements(themes) AS t
+                WHERE domain = ANY(%s)
+                  AND t->>'theme' IS NOT NULL
+                  AND t->>'theme' NOT LIKE 'TAX_ETHNICITY%%'
+                  AND t->>'theme' NOT LIKE 'TAX_WORLDLANGUAGE%%'
+                  AND t->>'theme' NOT LIKE 'TAX_FNCACT%%'
+                GROUP BY domain, t->>'theme'
+                ORDER BY domain, count(*) DESC
+                """,
+                (source_domains,),
+            )
+            theme_rows = cur.fetchall()
+
+            # Get top countries per source (top 5)
+            cur.execute(
+                """
+                SELECT domain,
+                       loc->>'country_code' AS country_code,
+                       count(*) AS cnt
+                FROM articles,
+                     jsonb_array_elements(locations) AS loc
+                WHERE domain = ANY(%s)
+                  AND loc->>'country_code' IS NOT NULL
+                GROUP BY domain, loc->>'country_code'
+                ORDER BY domain, count(*) DESC
+                """,
+                (source_domains,),
+            )
+            country_rows = cur.fetchall()
+
+    # Build theme map (top 8 per domain)
+    theme_map: dict[str, list[dict]] = defaultdict(list)
+    for row in theme_rows:
+        d = row["domain"]
+        if len(theme_map[d]) < 8:
+            category = _categorize_themes([row["theme"]])
+            theme_map[d].append(
+                {"theme": row["theme"], "count": row["cnt"], "category": category}
+            )
+
+    # Build country map (top 5 per domain)
+    country_map: dict[str, list[dict]] = defaultdict(list)
+    for row in country_rows:
+        d = row["domain"]
+        if len(country_map[d]) < 5:
+            country_map[d].append(
+                {"country_code": row["country_code"], "count": row["cnt"]}
+            )
+
+    results = []
+    for s in sources:
+        results.append(
+            {
+                "source_name": s["source_name"],
+                "domain": s["domain"],
+                "article_count": s["article_count"],
+                "avg_tone": round(s["avg_tone"], 3) if s["avg_tone"] else 0,
+                "avg_positive": round(s["avg_positive"], 3) if s["avg_positive"] else 0,
+                "avg_negative": round(s["avg_negative"], 3) if s["avg_negative"] else 0,
+                "avg_polarity": round(s["avg_polarity"], 3) if s["avg_polarity"] else 0,
+                "first_article": s["first_article"],
+                "last_article": s["last_article"],
+                "top_themes": theme_map.get(s["domain"], []),
+                "top_countries": country_map.get(s["domain"], []),
+            }
+        )
+
+    return results
+
+
+@app.get("/api/sources/{domain}/detail")
+def source_detail(domain: str):
+    """Detailed fingerprint for a single source domain."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            # Basic stats
+            cur.execute(
+                """
+                SELECT
+                    COALESCE(source_common_name, domain) AS source_name,
+                    domain,
+                    count(*) AS article_count,
+                    avg((tone->>'tone')::float) FILTER (WHERE tone->>'tone' IS NOT NULL)
+                        AS avg_tone,
+                    avg((tone->>'positive_score')::float)
+                        FILTER (WHERE tone->>'positive_score' IS NOT NULL) AS avg_positive,
+                    avg((tone->>'negative_score')::float)
+                        FILTER (WHERE tone->>'negative_score' IS NOT NULL) AS avg_negative,
+                    avg((tone->>'polarity')::float)
+                        FILTER (WHERE tone->>'polarity' IS NOT NULL) AS avg_polarity,
+                    min(gdelt_timestamp) AS first_article,
+                    max(gdelt_timestamp) AS last_article
+                FROM articles
+                WHERE domain = %s AND title IS NOT NULL
+                GROUP BY COALESCE(source_common_name, domain), domain
+                """,
+                (domain,),
+            )
+            stats = cur.fetchone()
+            if not stats:
+                raise HTTPException(status_code=404, detail="Source not found")
+
+            # Theme distribution (all themes)
+            cur.execute(
+                """
+                SELECT t->>'theme' AS theme, count(*) AS cnt
+                FROM articles, jsonb_array_elements(themes) AS t
+                WHERE domain = %s
+                  AND t->>'theme' IS NOT NULL
+                  AND t->>'theme' NOT LIKE 'TAX_ETHNICITY%%'
+                  AND t->>'theme' NOT LIKE 'TAX_WORLDLANGUAGE%%'
+                  AND t->>'theme' NOT LIKE 'TAX_FNCACT%%'
+                GROUP BY t->>'theme'
+                ORDER BY count(*) DESC
+                LIMIT 20
+                """,
+                (domain,),
+            )
+            themes = cur.fetchall()
+
+            # Country distribution
+            cur.execute(
+                """
+                SELECT loc->>'country_code' AS country_code, count(*) AS cnt
+                FROM articles, jsonb_array_elements(locations) AS loc
+                WHERE domain = %s AND loc->>'country_code' IS NOT NULL
+                GROUP BY loc->>'country_code'
+                ORDER BY count(*) DESC
+                LIMIT 15
+                """,
+                (domain,),
+            )
+            countries = cur.fetchall()
+
+            # Category distribution
+            cur.execute(
+                """
+                SELECT t->>'theme' AS theme
+                FROM articles, jsonb_array_elements(themes) AS t
+                WHERE domain = %s AND t->>'theme' IS NOT NULL
+                """,
+                (domain,),
+            )
+            all_theme_rows = cur.fetchall()
+
+            # Tone over time (by day)
+            cur.execute(
+                """
+                SELECT date_trunc('day', gdelt_timestamp) AS day,
+                       avg((tone->>'tone')::float) AS avg_tone,
+                       count(*) AS article_count
+                FROM articles
+                WHERE domain = %s
+                  AND tone->>'tone' IS NOT NULL
+                  AND gdelt_timestamp IS NOT NULL
+                GROUP BY date_trunc('day', gdelt_timestamp)
+                ORDER BY day
+                """,
+                (domain,),
+            )
+            tone_timeline = cur.fetchall()
+
+            # Recent articles (last 10)
+            cur.execute(
+                """
+                SELECT title, url, gdelt_timestamp,
+                       (tone->>'tone')::float AS tone_score
+                FROM articles
+                WHERE domain = %s AND title IS NOT NULL
+                ORDER BY gdelt_timestamp DESC
+                LIMIT 10
+                """,
+                (domain,),
+            )
+            recent = cur.fetchall()
+
+    # Build category breakdown
+    cat_counts: dict[str, int] = defaultdict(int)
+    for row in all_theme_rows:
+        cat = _categorize_themes([row["theme"]])
+        cat_counts[cat] += 1
+    total_themes = sum(cat_counts.values()) or 1
+    categories = [
+        {"category": cat, "count": cnt, "pct": round(cnt / total_themes * 100, 1)}
+        for cat, cnt in sorted(cat_counts.items(), key=lambda x: -x[1])
+    ]
+
+    return {
+        "source_name": stats["source_name"],
+        "domain": stats["domain"],
+        "article_count": stats["article_count"],
+        "avg_tone": round(stats["avg_tone"], 3) if stats["avg_tone"] else 0,
+        "avg_positive": round(stats["avg_positive"], 3) if stats["avg_positive"] else 0,
+        "avg_negative": round(stats["avg_negative"], 3) if stats["avg_negative"] else 0,
+        "avg_polarity": round(stats["avg_polarity"], 3) if stats["avg_polarity"] else 0,
+        "first_article": stats["first_article"],
+        "last_article": stats["last_article"],
+        "themes": [
+            {"theme": t["theme"], "count": t["cnt"], "category": _categorize_themes([t["theme"]])}
+            for t in themes
+        ],
+        "countries": [{"country_code": c["country_code"], "count": c["cnt"]} for c in countries],
+        "categories": categories,
+        "tone_timeline": [
+            {
+                "day": t["day"].isoformat() if t["day"] else None,
+                "avg_tone": round(t["avg_tone"], 3),
+                "article_count": t["article_count"],
+            }
+            for t in tone_timeline
+        ],
+        "recent_articles": [dict(r) for r in recent],
+    }
+
+
+# ── Story Propagation endpoints ──────────────────────────────────────
+
+
+@app.get("/api/propagation/stories")
+def propagation_stories(
+    limit: int = Query(20, ge=1, le=50, description="Max clusters to return"),
+    min_sources: int = Query(3, ge=2, description="Min distinct sources"),
+):
+    """Top stories suitable for propagation analysis (multi-source clusters)."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT c.id, c.representative_title, c.article_count,
+                       c.first_article_at, c.last_article_at,
+                       count(DISTINCT a.domain) AS source_count,
+                       EXTRACT(EPOCH FROM (c.last_article_at - c.first_article_at)) / 3600
+                           AS span_hours
+                FROM clusters c
+                JOIN cluster_memberships cm ON cm.cluster_id = c.id
+                JOIN articles a ON a.id = cm.article_id
+                WHERE c.is_active = true
+                  AND c.article_count >= 5
+                  AND a.title IS NOT NULL
+                GROUP BY c.id
+                HAVING count(DISTINCT a.domain) >= %s
+                ORDER BY c.article_count DESC
+                LIMIT %s
+                """,
+                (min_sources, limit),
+            )
+            stories = cur.fetchall()
+
+    return [
+        {
+            "id": str(s["id"]),
+            "title": s["representative_title"],
+            "article_count": s["article_count"],
+            "source_count": s["source_count"],
+            "span_hours": round(s["span_hours"], 1) if s["span_hours"] else 0,
+            "first_article_at": s["first_article_at"],
+            "last_article_at": s["last_article_at"],
+        }
+        for s in stories
+    ]
+
+
+@app.get("/api/propagation/{cluster_id}")
+def propagation_timeline(cluster_id: str):
+    """Timeline of how a story propagated across sources over time."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            # Verify cluster exists
+            cur.execute(
+                "SELECT id, representative_title, article_count, "
+                "first_article_at, last_article_at "
+                "FROM clusters WHERE id = %s",
+                (cluster_id,),
+            )
+            cluster = cur.fetchone()
+            if not cluster:
+                raise HTTPException(status_code=404, detail="Cluster not found")
+
+            # All articles in chronological order with source info
+            cur.execute(
+                """
+                SELECT a.title, a.url, a.domain,
+                       COALESCE(a.source_common_name, a.domain) AS source_name,
+                       a.gdelt_timestamp,
+                       (a.tone->>'tone')::float AS tone_score,
+                       a.locations
+                FROM cluster_memberships cm
+                JOIN articles a ON a.id = cm.article_id
+                WHERE cm.cluster_id = %s
+                  AND a.title IS NOT NULL
+                ORDER BY a.gdelt_timestamp ASC
+                """,
+                (cluster_id,),
+            )
+            articles = cur.fetchall()
+
+    if not articles:
+        raise HTTPException(status_code=404, detail="No articles found for cluster")
+
+    # Build timeline events
+    events = []
+    seen_sources = set()
+    source_first_seen: dict[str, int] = {}
+
+    for i, a in enumerate(articles):
+        domain = a["domain"]
+        is_first = domain not in seen_sources
+        if is_first:
+            source_first_seen[domain] = i
+            seen_sources.add(domain)
+
+        # Extract primary location
+        loc_name = None
+        if a["locations"] and isinstance(a["locations"], list) and a["locations"]:
+            loc_name = a["locations"][0].get("name")
+
+        events.append(
+            {
+                "title": a["title"],
+                "url": a["url"],
+                "domain": domain,
+                "source_name": a["source_name"],
+                "timestamp": a["gdelt_timestamp"],
+                "tone": round(a["tone_score"], 2) if a["tone_score"] is not None else None,
+                "location": loc_name,
+                "is_first_from_source": is_first,
+                "order": i,
+            }
+        )
+
+    # Source summary: when each source first picked up the story
+    source_summary = []
+    for domain, first_idx in sorted(source_first_seen.items(), key=lambda x: x[1]):
+        arts = [e for e in events if e["domain"] == domain]
+        source_summary.append(
+            {
+                "domain": domain,
+                "source_name": arts[0]["source_name"],
+                "first_timestamp": arts[0]["timestamp"],
+                "article_count": len(arts),
+                "avg_tone": round(
+                    sum(a["tone"] for a in arts if a["tone"] is not None)
+                    / max(1, sum(1 for a in arts if a["tone"] is not None)),
+                    2,
+                ),
+                "order": first_idx,
+            }
+        )
+
+    # Hourly histogram
+    if articles:
+        first_ts = articles[0]["gdelt_timestamp"]
+        if first_ts.tzinfo is None:
+            first_ts = first_ts.replace(tzinfo=datetime.now().astimezone().tzinfo)
+        hourly: dict[int, int] = defaultdict(int)
+        for a in articles:
+            ts = a["gdelt_timestamp"]
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=first_ts.tzinfo)
+            hour = int((ts - first_ts).total_seconds() / 3600)
+            hourly[hour] += 1
+        max_hour = max(hourly.keys()) if hourly else 0
+        histogram = [{"hour": h, "count": hourly.get(h, 0)} for h in range(max_hour + 1)]
+    else:
+        histogram = []
+
+    return {
+        "cluster_id": str(cluster["id"]),
+        "title": cluster["representative_title"],
+        "article_count": cluster["article_count"],
+        "first_article_at": cluster["first_article_at"],
+        "last_article_at": cluster["last_article_at"],
+        "source_count": len(source_summary),
+        "timeline": events,
+        "sources": source_summary,
+        "hourly_histogram": histogram,
+    }
+
+
+# ── Topic Velocity endpoints ─────────────────────────────────────────
+
+
+@app.get("/api/velocity/topics")
+def velocity_topics(
+    hours: int = Query(48, ge=6, le=168, description="Lookback window in hours"),
+    limit: int = Query(30, ge=5, le=100, description="Max topics to return"),
+):
+    """Trending topics with velocity (acceleration/deceleration) over time windows."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            half = hours // 2
+
+            def _velocity_query(order: str, min_recent: int, min_older: int):
+                return f"""
+                WITH ref AS (SELECT max(gdelt_timestamp) AS max_ts FROM articles),
+                recent AS (
+                    SELECT th->>'theme' AS theme, count(*) AS cnt
+                    FROM articles, jsonb_array_elements(themes) AS th, ref
+                    WHERE gdelt_timestamp > ref.max_ts - interval '{half} hours'
+                      AND th->>'theme' IS NOT NULL
+                      AND th->>'theme' NOT LIKE 'TAX_ETHNICITY%%'
+                      AND th->>'theme' NOT LIKE 'TAX_WORLDLANGUAGE%%'
+                      AND th->>'theme' NOT LIKE 'TAX_FNCACT%%'
+                    GROUP BY th->>'theme'
+                    HAVING count(*) >= {min_recent}
+                ),
+                older AS (
+                    SELECT th->>'theme' AS theme, count(*) AS cnt
+                    FROM articles, jsonb_array_elements(themes) AS th, ref
+                    WHERE gdelt_timestamp >= ref.max_ts - interval '{hours} hours'
+                      AND gdelt_timestamp <= ref.max_ts - interval '{half} hours'
+                      AND th->>'theme' IS NOT NULL
+                      AND th->>'theme' NOT LIKE 'TAX_ETHNICITY%%'
+                      AND th->>'theme' NOT LIKE 'TAX_WORLDLANGUAGE%%'
+                      AND th->>'theme' NOT LIKE 'TAX_FNCACT%%'
+                    GROUP BY th->>'theme'
+                    HAVING count(*) >= {min_older}
+                )
+                SELECT
+                    COALESCE(r.theme, o.theme) AS theme,
+                    COALESCE(r.cnt, 0) AS recent_count,
+                    COALESCE(o.cnt, 0) AS older_count,
+                    COALESCE(r.cnt, 0) + COALESCE(o.cnt, 0) AS total_count,
+                    CASE
+                        WHEN COALESCE(o.cnt, 0) = 0 AND COALESCE(r.cnt, 0) > 0 THEN 100.0
+                        WHEN COALESCE(o.cnt, 0) > 0
+                            THEN round(
+                                ((COALESCE(r.cnt, 0) - o.cnt)::numeric / o.cnt * 100), 1
+                            )
+                        ELSE 0
+                    END AS velocity_pct
+                FROM recent r
+                FULL OUTER JOIN older o ON r.theme = o.theme
+                WHERE COALESCE(r.cnt, 0) + COALESCE(o.cnt, 0) >= 5
+                ORDER BY velocity_pct {order}
+                LIMIT %s
+                """
+
+            cur.execute(_velocity_query("DESC", 3, 1), (limit,))
+            rising = cur.fetchall()
+
+            cur.execute(_velocity_query("ASC", 2, 5), (limit,))
+            declining = cur.fetchall()
+
+    def format_topic(row):
+        theme = row["theme"]
+        return {
+            "theme": theme,
+            "category": _categorize_themes([theme]),
+            "recent_count": row["recent_count"],
+            "older_count": row["older_count"],
+            "total_count": row["total_count"],
+            "velocity_pct": float(row["velocity_pct"]),
+        }
+
+    return {
+        "window_hours": hours,
+        "rising": [format_topic(r) for r in rising],
+        "declining": [format_topic(r) for r in declining],
+    }
+
+
+@app.get("/api/velocity/timeline")
+def velocity_timeline(
+    theme: str = Query(..., description="Theme to get timeline for"),
+    hours: int = Query(72, ge=6, le=168, description="Lookback window"),
+):
+    """Hourly article count for a specific theme."""
+    from gdelt_event_pipeline.storage.database import get_pool
+
+    pool = get_pool()
+    with pool.connection() as conn:
+        from psycopg.rows import dict_row
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                WITH ref AS (SELECT max(gdelt_timestamp) AS max_ts FROM articles)
+                SELECT date_trunc('hour', gdelt_timestamp) AS hour,
+                       count(*) AS cnt,
+                       avg((tone->>'tone')::float) FILTER (WHERE tone->>'tone' IS NOT NULL)
+                           AS avg_tone
+                FROM articles, jsonb_array_elements(themes) AS th, ref
+                WHERE th->>'theme' = %s
+                  AND gdelt_timestamp >= ref.max_ts - interval '%s hours'
+                GROUP BY date_trunc('hour', gdelt_timestamp)
+                ORDER BY hour
+                """,
+                (theme, hours),
+            )
+            rows = cur.fetchall()
+
+            cur.execute(
+                """
+                WITH ref AS (SELECT max(gdelt_timestamp) AS max_ts FROM articles)
+                SELECT a.title, a.url, a.domain, a.gdelt_timestamp,
+                       (a.tone->>'tone')::float AS tone_score
+                FROM articles a, jsonb_array_elements(a.themes) AS th, ref
+                WHERE th->>'theme' = %s
+                  AND a.title IS NOT NULL
+                  AND a.gdelt_timestamp >= ref.max_ts - interval '%s hours'
+                ORDER BY a.gdelt_timestamp DESC
+                LIMIT 10
+                """,
+                (theme, hours),
+            )
+            articles = cur.fetchall()
+
+    return {
+        "theme": theme,
+        "category": _categorize_themes([theme]),
+        "timeline": [
+            {
+                "hour": r["hour"].isoformat() if r["hour"] else None,
+                "count": r["cnt"],
+                "avg_tone": round(r["avg_tone"], 3) if r["avg_tone"] else None,
+            }
+            for r in rows
+        ],
+        "recent_articles": [dict(a) for a in articles],
+    }
+
 
 
 # ── Runner ────────────────────────────────────────────────────────────

--- a/src/gdelt_event_pipeline/api/app.py
+++ b/src/gdelt_event_pipeline/api/app.py
@@ -96,9 +96,7 @@ def _ensure_schema() -> None:
                 ")"
             )
             row = cur.fetchone()
-            exists = (
-                row[0] if isinstance(row, (tuple, list)) else row.get("exists", False)
-            )
+            exists = row[0] if isinstance(row, (tuple, list)) else row.get("exists", False)
         if not exists:
             logger.info("Tables not found — running schema initialization...")
             schema_path = Path(__file__).resolve().parents[3] / "sql" / "001_schema.sql"
@@ -170,9 +168,7 @@ async def rate_limit_middleware(request: Request, call_next) -> Response:
 
     # Prune old entries
     timestamps = _rate_limit_store[client_ip]
-    _rate_limit_store[client_ip] = [
-        t for t in timestamps if now - t < RATE_LIMIT_WINDOW
-    ]
+    _rate_limit_store[client_ip] = [t for t in timestamps if now - t < RATE_LIMIT_WINDOW]
 
     if len(_rate_limit_store[client_ip]) >= RATE_LIMIT_MAX:
         return Response(
@@ -240,26 +236,16 @@ def velocity_page():
 def search(
     q: str = Query(..., description="Search query text"),
     limit: int = Query(20, ge=1, le=100, description="Max results"),
-    semantic_weight: float = Query(
-        0.5, ge=0.0, le=1.0, description="Semantic vs keyword weight"
-    ),
+    semantic_weight: float = Query(0.5, ge=0.0, le=1.0, description="Semantic vs keyword weight"),
     clusters: bool = Query(False, description="Also search cluster centroids"),
-    location: str | None = Query(
-        None, description="Filter by location (comma-separated)"
-    ),
+    location: str | None = Query(None, description="Filter by location (comma-separated)"),
     person: str | None = Query(None, description="Filter by person (comma-separated)"),
-    org: str | None = Query(
-        None, description="Filter by organization (comma-separated)"
-    ),
+    org: str | None = Query(None, description="Filter by organization (comma-separated)"),
     theme: str | None = Query(None, description="Filter by theme (comma-separated)"),
     domain: str | None = Query(None, description="Filter by domain (comma-separated)"),
     source: str | None = Query(None, description="Filter by source (comma-separated)"),
-    date_from: datetime | None = Query(
-        None, description="Start date (ISO format)"
-    ),  # noqa: B008
-    date_to: datetime | None = Query(
-        None, description="End date (ISO format)"
-    ),  # noqa: B008
+    date_from: datetime | None = Query(None, description="Start date (ISO format)"),  # noqa: B008
+    date_to: datetime | None = Query(None, description="End date (ISO format)"),  # noqa: B008
 ):
     """Hybrid semantic + keyword search over articles and clusters."""
     filters = SearchFilters(
@@ -272,9 +258,7 @@ def search(
         date_from=date_from,
         date_to=date_to,
     )
-    has_filters = any(
-        getattr(filters, f) is not None for f in filters.__dataclass_fields__
-    )
+    has_filters = any(getattr(filters, f) is not None for f in filters.__dataclass_fields__)
 
     request = SearchRequest(
         query=q,
@@ -322,15 +306,11 @@ def get_stats():
             total_articles = cur.fetchone()["cnt"]
             cur.execute("SELECT count(*) AS cnt FROM articles WHERE title IS NOT NULL")
             titled = cur.fetchone()["cnt"]
-            cur.execute(
-                "SELECT count(*) AS cnt FROM articles WHERE embedding IS NOT NULL"
-            )
+            cur.execute("SELECT count(*) AS cnt FROM articles WHERE embedding IS NOT NULL")
             embedded = cur.fetchone()["cnt"]
             cur.execute("SELECT count(*) AS cnt FROM clusters WHERE is_active = true")
             total_clusters = cur.fetchone()["cnt"]
-            cur.execute(
-                "SELECT max(article_count) AS val FROM clusters WHERE is_active = true"
-            )
+            cur.execute("SELECT max(article_count) AS val FROM clusters WHERE is_active = true")
             largest_cluster = cur.fetchone()["val"] or 0
             cur.execute("SELECT count(*) AS cnt FROM cluster_memberships")
             total_memberships = cur.fetchone()["cnt"]
@@ -357,22 +337,14 @@ def list_articles(
 def list_clusters(
     limit: int = Query(100, ge=1, le=500, description="Max clusters to return"),
     sort: str = Query("recent", description="Sort: recent, articles, oldest"),
-    location: str | None = Query(
-        None, description="Filter by location (comma-separated)"
-    ),
+    location: str | None = Query(None, description="Filter by location (comma-separated)"),
     person: str | None = Query(None, description="Filter by person (comma-separated)"),
-    org: str | None = Query(
-        None, description="Filter by organization (comma-separated)"
-    ),
+    org: str | None = Query(None, description="Filter by organization (comma-separated)"),
     theme: str | None = Query(None, description="Filter by theme (comma-separated)"),
     domain: str | None = Query(None, description="Filter by domain (comma-separated)"),
     source: str | None = Query(None, description="Filter by source (comma-separated)"),
-    date_from: datetime | None = Query(
-        None, description="Start date (ISO format)"
-    ),  # noqa: B008
-    date_to: datetime | None = Query(
-        None, description="End date (ISO format)"
-    ),  # noqa: B008
+    date_from: datetime | None = Query(None, description="Start date (ISO format)"),  # noqa: B008
+    date_to: datetime | None = Query(None, description="End date (ISO format)"),  # noqa: B008
 ):
     """List active clusters, optionally filtered by article metadata."""
     locations = _split_csv(location)
@@ -425,9 +397,7 @@ def list_clusters(
         article_conditions.append("a.domain ILIKE %s")
         params.append(f"%{domains[0]}%")
     if sources:
-        article_conditions.append(
-            "(a.source_common_name ILIKE %s OR a.canonical_source ILIKE %s)"
-        )
+        article_conditions.append("(a.source_common_name ILIKE %s OR a.canonical_source ILIKE %s)")
         params.extend([f"%{sources[0]}%", f"%{sources[0]}%"])
     if date_from:
         article_conditions.append("a.gdelt_timestamp >= %s")
@@ -690,9 +660,7 @@ def globe_clusters(
                 "article_count": c["article_count"],
                 "recent_count": c.get("recent_count", 0),
                 "velocity": round(c.get("velocity", 0), 3),
-                "silent_hours": (
-                    round(c["silent_hours"], 1) if c.get("silent_hours") else None
-                ),
+                "silent_hours": (round(c["silent_hours"], 1) if c.get("silent_hours") else None),
                 "age_hours": round(c["age_hours"], 1) if c.get("age_hours") else None,
                 "lat": lat,
                 "lon": lon,
@@ -866,9 +834,7 @@ def _categorize_themes(themes: list[str]) -> str:
 @app.get("/api/polarization")
 def get_polarization(
     limit: int = Query(30, ge=1, le=100, description="Max clusters to return"),
-    min_articles: int = Query(
-        20, ge=5, le=500, description="Minimum articles per cluster"
-    ),
+    min_articles: int = Query(20, ge=5, le=500, description="Minimum articles per cluster"),
 ):
     """Return the most narratively polarized story clusters.
 
@@ -1063,18 +1029,12 @@ def get_polarization_detail(cluster_id: str):
                 "domain": a["domain"],
                 "gdelt_timestamp": a["gdelt_timestamp"],
                 "tone": round(a["tone"], 3) if a["tone"] is not None else None,
-                "polarity": (
-                    round(a["polarity"], 3) if a["polarity"] is not None else None
-                ),
+                "polarity": (round(a["polarity"], 3) if a["polarity"] is not None else None),
                 "positive_score": (
-                    round(a["positive_score"], 3)
-                    if a["positive_score"] is not None
-                    else None
+                    round(a["positive_score"], 3) if a["positive_score"] is not None else None
                 ),
                 "negative_score": (
-                    round(a["negative_score"], 3)
-                    if a["negative_score"] is not None
-                    else None
+                    round(a["negative_score"], 3) if a["negative_score"] is not None else None
                 ),
             }
         )
@@ -1097,9 +1057,7 @@ def get_polarization_detail(cluster_id: str):
     # Overall stats
     all_tones = [a["tone"] for a in articles if a["tone"] is not None]
     avg = sum(all_tones) / len(all_tones) if all_tones else 0
-    variance = (
-        sum((t - avg) ** 2 for t in all_tones) / len(all_tones) if all_tones else 0
-    )
+    variance = sum((t - avg) ** 2 for t in all_tones) / len(all_tones) if all_tones else 0
     stddev = variance**0.5
 
     return {
@@ -1236,15 +1194,11 @@ def get_asymmetry():
                 "code": c["code"],
                 "article_count": c["article_count"],
                 "coverage_pct": (
-                    round(c["article_count"] / total_articles * 100, 3)
-                    if total_articles
-                    else 0
+                    round(c["article_count"] / total_articles * 100, 3) if total_articles else 0
                 ),
                 "crisis_articles": crisis_count,
                 "crisis_ratio": (
-                    round(crisis_count / c["article_count"], 3)
-                    if c["article_count"]
-                    else 0
+                    round(crisis_count / c["article_count"], 3) if c["article_count"] else 0
                 ),
                 "avg_tone": float(c["avg_tone"]) if c["avg_tone"] is not None else 0,
             }
@@ -1282,9 +1236,7 @@ def get_asymmetry():
 
 @app.get("/api/gravity/graph")
 def gravity_graph(
-    min_weight: int = Query(
-        50, ge=10, le=5000, description="Minimum co-mention count for edges"
-    ),
+    min_weight: int = Query(50, ge=10, le=5000, description="Minimum co-mention count for edges"),
     limit_edges: int = Query(80, ge=10, le=300, description="Max edges to return"),
 ):
     """Return country co-mention graph for the geopolitical gravity map.
@@ -1415,9 +1367,7 @@ def gravity_country_detail(code: str):
         "code": code,
         "article_count": stats["article_count"],
         "avg_tone": float(stats["avg_tone"]) if stats["avg_tone"] is not None else 0,
-        "connections": [
-            {"code": c["connected_code"], "weight": c["weight"]} for c in connections
-        ],
+        "connections": [{"code": c["connected_code"], "weight": c["weight"]} for c in connections],
         "top_clusters": [
             {
                 "id": str(c["id"]),
@@ -1438,12 +1388,8 @@ def gravity_country_detail(code: str):
 @app.get("/api/sources/fingerprints")
 def source_fingerprints(
     limit: int = Query(50, ge=1, le=200, description="Max sources to return"),
-    sort: str = Query(
-        "articles", description="Sort: articles, tone_positive, tone_negative"
-    ),
-    min_articles: int = Query(
-        10, ge=1, description="Minimum articles to include source"
-    ),
+    sort: str = Query("articles", description="Sort: articles, tone_positive, tone_negative"),
+    min_articles: int = Query(10, ge=1, description="Minimum articles to include source"),
 ):
     """Per-source fingerprints: article count, avg tone, top themes, top countries."""
     from gdelt_event_pipeline.storage.database import get_pool
@@ -1532,18 +1478,14 @@ def source_fingerprints(
         d = row["domain"]
         if len(theme_map[d]) < 8:
             category = _categorize_themes([row["theme"]])
-            theme_map[d].append(
-                {"theme": row["theme"], "count": row["cnt"], "category": category}
-            )
+            theme_map[d].append({"theme": row["theme"], "count": row["cnt"], "category": category})
 
     # Build country map (top 5 per domain)
     country_map: dict[str, list[dict]] = defaultdict(list)
     for row in country_rows:
         d = row["domain"]
         if len(country_map[d]) < 5:
-            country_map[d].append(
-                {"country_code": row["country_code"], "count": row["cnt"]}
-            )
+            country_map[d].append({"country_code": row["country_code"], "count": row["cnt"]})
 
     results = []
     for s in sources:
@@ -1706,9 +1648,7 @@ def source_detail(domain: str):
             }
             for t in themes
         ],
-        "countries": [
-            {"country_code": c["country_code"], "count": c["cnt"]} for c in countries
-        ],
+        "countries": [{"country_code": c["country_code"], "count": c["cnt"]} for c in countries],
         "categories": categories,
         "tone_timeline": [
             {
@@ -1840,9 +1780,7 @@ def propagation_timeline(cluster_id: str):
                 "domain": domain,
                 "source_name": a["source_name"],
                 "timestamp": a["gdelt_timestamp"],
-                "tone": (
-                    round(a["tone_score"], 2) if a["tone_score"] is not None else None
-                ),
+                "tone": (round(a["tone_score"], 2) if a["tone_score"] is not None else None),
                 "location": loc_name,
                 "is_first_from_source": is_first,
                 "order": i,
@@ -1881,9 +1819,7 @@ def propagation_timeline(cluster_id: str):
             hour = int((ts - first_ts).total_seconds() / 3600)
             hourly[hour] += 1
         max_hour = max(hourly.keys()) if hourly else 0
-        histogram = [
-            {"hour": h, "count": hourly.get(h, 0)} for h in range(max_hour + 1)
-        ]
+        histogram = [{"hour": h, "count": hourly.get(h, 0)} for h in range(max_hour + 1)]
     else:
         histogram = []
 
@@ -2056,9 +1992,7 @@ def run() -> None:
     """Convenience entry point: uvicorn gdelt_event_pipeline.api.app:app"""
     import uvicorn
 
-    uvicorn.run(
-        "gdelt_event_pipeline.api.app:app", host="0.0.0.0", port=8000, reload=True
-    )
+    uvicorn.run("gdelt_event_pipeline.api.app:app", host="0.0.0.0", port=8000, reload=True)
 
 
 if __name__ == "__main__":

--- a/src/gdelt_event_pipeline/api/static/asymmetry.html
+++ b/src/gdelt_event_pipeline/api/static/asymmetry.html
@@ -1,0 +1,757 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Attention Asymmetry | GDELT Pulse</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+
+:root{
+  --bg:#050507;--bg-raised:#0c0c10;--surface:#111116;--surface-2:#17171d;
+  --surface-3:#1d1d25;--border:#222230;--border-dim:#1a1a24;
+  --text:#ededf0;--text-2:#b0b0be;--text-3:#6e6e82;
+  --primary:#7c6aef;--primary-light:#9d8ff5;--primary-dim:rgba(124,106,239,0.1);
+  --teal:#2dd4a8;--teal-dim:rgba(45,212,168,0.1);
+  --amber:#e5a63e;--amber-dim:rgba(229,166,62,0.1);
+  --rose:#e5637a;--rose-dim:rgba(229,99,122,0.1);
+  --glass-bg:rgba(17,17,22,0.4);--glass-border:rgba(255,255,255,0.06);
+  --glass-blur:20px;--ease:cubic-bezier(0.4,0,0.2,1);
+}
+
+body{
+  font-family:'DM Sans',-apple-system,sans-serif;
+  background:var(--bg);color:var(--text);
+  min-height:100vh;line-height:1.55;
+  -webkit-font-smoothing:antialiased;overflow-x:hidden;
+}
+
+::selection{background:var(--primary-dim);color:var(--primary-light)}
+::-webkit-scrollbar{width:6px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:var(--border-dim);border-radius:3px}
+
+/* ── Top bar ──────────────────────────────────── */
+
+.topbar{
+  position:fixed;top:0;left:0;right:0;z-index:100;
+  display:flex;align-items:center;gap:16px;
+  padding:14px 24px;
+  background:rgba(5,5,7,0.8);backdrop-filter:blur(20px) saturate(1.6);
+  -webkit-backdrop-filter:blur(20px) saturate(1.6);
+  border-bottom:1px solid var(--glass-border);
+}
+
+.topbar-back{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:6px 14px;border-radius:20px;
+  border:1px solid var(--border-dim);background:none;
+  color:var(--text-2);font-size:0.78rem;font-family:inherit;
+  font-weight:500;cursor:pointer;text-decoration:none;
+  transition:all 0.2s var(--ease);
+}
+.topbar-back:hover{color:var(--text);border-color:var(--border)}
+.topbar-back svg{width:14px;height:14px}
+
+.topbar-title{font-size:0.9rem;font-weight:600;letter-spacing:-0.02em}
+.topbar-title .accent{color:var(--primary-light)}
+
+/* ── Page ─────────────────────────────────────── */
+
+.page-wrap{max-width:1060px;margin:0 auto;padding:80px 24px 60px}
+
+.page-intro{
+  text-align:center;margin-bottom:40px;
+  animation:fadeUp 0.6s var(--ease) both;
+}
+
+.page-intro h1{
+  font-size:clamp(1.8rem,4vw,2.6rem);
+  font-weight:700;letter-spacing:-0.04em;margin-bottom:10px;
+}
+
+.page-intro h1 .accent{
+  background:linear-gradient(135deg,var(--amber),var(--primary-light),var(--rose));
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  background-clip:text;
+}
+
+.page-intro p{font-size:0.92rem;color:var(--text-3);max-width:560px;margin:0 auto}
+
+@keyframes fadeUp{
+  from{opacity:0;transform:translateY(18px)}
+  to{opacity:1;transform:translateY(0)}
+}
+
+/* ── Overview stats ───────────────────────────── */
+
+.ov-stats{
+  display:flex;gap:10px;margin-bottom:32px;
+  animation:fadeUp 0.6s var(--ease) 0.1s both;
+}
+
+.ov-stat{
+  flex:1;text-align:center;padding:18px 14px;
+  background:var(--glass-bg);backdrop-filter:blur(var(--glass-blur));
+  border:1px solid var(--glass-border);border-radius:14px;
+}
+
+.ov-stat-val{
+  font-family:'JetBrains Mono',monospace;
+  font-size:1.4rem;font-weight:600;margin-bottom:2px;
+}
+
+.ov-stat-label{
+  font-size:0.66rem;text-transform:uppercase;
+  letter-spacing:0.07em;color:var(--text-3);font-weight:500;
+}
+
+/* ── Charts ───────────────────────────────────── */
+
+.chart-section{
+  background:var(--surface);border:1px solid var(--border-dim);
+  border-radius:16px;padding:24px;margin-bottom:20px;
+  animation:fadeUp 0.6s var(--ease) both;
+}
+
+.chart-section h3{
+  font-size:0.72rem;text-transform:uppercase;
+  letter-spacing:0.07em;color:var(--text-3);
+  font-weight:600;margin-bottom:4px;
+}
+
+.chart-section .chart-sub{
+  font-size:0.78rem;color:var(--text-3);margin-bottom:16px;
+}
+
+.chart-container{position:relative;height:320px}
+.chart-container.tall{height:400px}
+
+/* ── Treemap ──────────────────────────────────── */
+
+.treemap-wrap{
+  position:relative;height:360px;border-radius:10px;
+  overflow:hidden;margin-bottom:8px;
+}
+
+.tm-cell{
+  position:absolute;border:1px solid rgba(5,5,7,0.6);
+  border-radius:4px;overflow:hidden;
+  display:flex;flex-direction:column;
+  align-items:center;justify-content:center;
+  cursor:pointer;transition:filter 0.2s,transform 0.15s;
+  text-align:center;padding:4px;
+}
+
+.tm-cell:hover{filter:brightness(1.25);transform:scale(1.02);z-index:2}
+
+.tm-cell .tm-code{
+  font-family:'JetBrains Mono',monospace;
+  font-size:0.72rem;font-weight:600;color:rgba(255,255,255,0.9);
+  text-shadow:0 1px 3px rgba(0,0,0,0.5);
+}
+
+.tm-cell .tm-count{
+  font-family:'JetBrains Mono',monospace;
+  font-size:0.6rem;color:rgba(255,255,255,0.6);
+  text-shadow:0 1px 3px rgba(0,0,0,0.5);
+}
+
+/* ── Two column layout ────────────────────────── */
+
+.two-col{
+  display:grid;grid-template-columns:1fr 1fr;gap:16px;
+  margin-bottom:20px;
+}
+
+/* ── Story panels ─────────────────────────────── */
+
+.story-panel{
+  background:var(--surface);border:1px solid var(--border-dim);
+  border-radius:16px;padding:24px;
+  animation:fadeUp 0.6s var(--ease) both;
+}
+
+.story-panel h3{
+  font-size:0.72rem;text-transform:uppercase;
+  letter-spacing:0.07em;font-weight:600;margin-bottom:14px;
+  display:flex;align-items:center;gap:8px;
+}
+
+.story-panel h3 .dot{
+  width:8px;height:8px;border-radius:50%;flex-shrink:0;
+}
+
+.story-card{
+  padding:12px 14px;background:var(--bg);
+  border:1px solid var(--border-dim);border-radius:10px;
+  margin-bottom:6px;transition:all 0.2s var(--ease);
+}
+
+.story-card:hover{border-color:rgba(124,106,239,0.3);background:var(--surface-2)}
+
+.story-title{
+  font-size:0.82rem;font-weight:500;line-height:1.35;
+  margin-bottom:4px;letter-spacing:-0.01em;
+  display:-webkit-box;-webkit-line-clamp:2;
+  -webkit-box-orient:vertical;overflow:hidden;
+}
+
+.story-meta{
+  display:flex;gap:10px;font-size:0.7rem;color:var(--text-3);
+}
+
+.story-meta .mono{font-family:'JetBrains Mono',monospace}
+
+.story-badge{
+  font-family:'JetBrains Mono',monospace;
+  font-size:0.66rem;font-weight:600;
+  padding:3px 8px;border-radius:12px;
+}
+
+.badge-over{color:var(--amber);background:var(--amber-dim)}
+.badge-under{color:var(--rose);background:var(--rose-dim)}
+
+/* ── Country table ────────────────────────────── */
+
+.country-table-wrap{
+  max-height:400px;overflow-y:auto;
+  border-radius:10px;
+}
+
+.country-table{
+  width:100%;border-collapse:collapse;font-size:0.8rem;
+}
+
+.country-table th{
+  position:sticky;top:0;z-index:2;
+  padding:10px 12px;text-align:left;
+  font-size:0.64rem;text-transform:uppercase;
+  letter-spacing:0.06em;color:var(--text-3);
+  font-weight:600;background:var(--surface);
+  border-bottom:1px solid var(--border-dim);
+}
+
+.country-table th.sortable{cursor:pointer;user-select:none}
+.country-table th.sortable:hover{color:var(--text-2)}
+.country-table th.sorted{color:var(--primary-light)}
+
+.country-table td{
+  padding:8px 12px;border-bottom:1px solid rgba(34,34,48,0.3);
+  vertical-align:middle;
+}
+
+.country-table tr:hover td{background:var(--surface-2)}
+
+.country-table .mono{font-family:'JetBrains Mono',monospace}
+
+.coverage-bar{
+  display:inline-block;height:4px;border-radius:2px;
+  background:var(--primary);vertical-align:middle;
+  margin-left:6px;transition:width 0.4s var(--ease);
+}
+
+.crisis-bar{
+  display:inline-block;height:4px;border-radius:2px;
+  background:var(--rose);vertical-align:middle;
+  margin-left:6px;transition:width 0.4s var(--ease);
+}
+
+/* ── Tooltip ──────────────────────────────────── */
+
+.tooltip{
+  position:fixed;z-index:200;
+  background:rgba(12,12,16,0.95);backdrop-filter:blur(16px);
+  -webkit-backdrop-filter:blur(16px);
+  border:1px solid var(--glass-border);
+  border-radius:12px;padding:14px 16px;
+  pointer-events:none;opacity:0;transition:opacity 0.15s;
+  max-width:240px;
+}
+
+.tooltip.visible{opacity:1}
+
+.tooltip-name{font-size:0.88rem;font-weight:600;margin-bottom:4px}
+
+.tooltip-row{
+  display:flex;justify-content:space-between;gap:16px;
+  font-size:0.74rem;color:var(--text-3);margin-bottom:2px;
+}
+
+.tooltip-row .val{
+  font-family:'JetBrains Mono',monospace;
+  color:var(--text-2);font-weight:500;
+}
+
+/* ── Loading ──────────────────────────────────── */
+
+.loading{
+  text-align:center;padding:48px 20px;
+  color:var(--text-3);font-size:0.86rem;
+}
+
+.spinner{
+  display:inline-block;width:16px;height:16px;
+  border:2px solid var(--border);border-top-color:var(--primary);
+  border-radius:50%;animation:spin 0.5s linear infinite;
+  margin-left:8px;vertical-align:middle;
+}
+
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* ── Responsive ───────────────────────────────── */
+
+@media(max-width:768px){
+  .page-wrap{padding:72px 14px 40px}
+  .ov-stats{flex-direction:column}
+  .two-col{grid-template-columns:1fr}
+  .treemap-wrap{height:280px}
+}
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <a href="/" class="topbar-back">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+  <span class="topbar-title">Attention <span class="accent">Asymmetry</span></span>
+</div>
+
+<div class="tooltip" id="tooltip"></div>
+
+<div class="page-wrap">
+  <div class="page-intro">
+    <h1>Attention <span class="accent">Asymmetry</span></h1>
+    <p>Where the world looks vs. where crises happen. Comparing media attention with crisis intensity to find the blind spots.</p>
+  </div>
+
+  <div class="ov-stats">
+    <div class="ov-stat"><div class="ov-stat-val" id="statTotal">--</div><div class="ov-stat-label">Total Articles</div></div>
+    <div class="ov-stat"><div class="ov-stat-val" id="statCountries">--</div><div class="ov-stat-label">Countries Covered</div></div>
+    <div class="ov-stat"><div class="ov-stat-val" id="statTopPct">--</div><div class="ov-stat-label">Top 5 Countries Share</div></div>
+    <div class="ov-stat"><div class="ov-stat-val" id="statGini">--</div><div class="ov-stat-label">Concentration Index</div></div>
+  </div>
+
+  <!-- Treemap: visual coverage distribution -->
+  <div class="chart-section" style="animation-delay:0.15s">
+    <h3>Coverage Distribution</h3>
+    <div class="chart-sub">Each block = one country. Size = article volume. Color = crisis intensity (red = high crisis ratio).</div>
+    <div class="treemap-wrap" id="treemap"></div>
+  </div>
+
+  <!-- Scatter: coverage vs crisis ratio -->
+  <div class="chart-section" style="animation-delay:0.2s">
+    <h3>The Blind Spot Map</h3>
+    <div class="chart-sub">Countries in the top-right are well-covered crisis zones. Bottom-right = crises that media is ignoring.</div>
+    <div class="chart-container tall"><canvas id="scatterChart"></canvas></div>
+  </div>
+
+  <!-- Overcovered vs Underreported -->
+  <div class="two-col">
+    <div class="story-panel" style="animation-delay:0.25s">
+      <h3><span class="dot" style="background:var(--amber)"></span> <span style="color:var(--amber)">Most Covered</span> Stories</h3>
+      <div id="overcoveredList"><div class="loading"><span class="spinner"></span></div></div>
+    </div>
+    <div class="story-panel" style="animation-delay:0.3s">
+      <h3><span class="dot" style="background:var(--rose)"></span> <span style="color:var(--rose)">Underreported</span> Crises</h3>
+      <div id="underreportedList"><div class="loading"><span class="spinner"></span></div></div>
+    </div>
+  </div>
+
+  <!-- Full country table -->
+  <div class="chart-section" style="animation-delay:0.35s">
+    <h3>All Countries</h3>
+    <div class="chart-sub">Click column headers to sort. Coverage % shows share of total articles.</div>
+    <div class="country-table-wrap">
+      <table class="country-table" id="countryTable">
+        <thead>
+          <tr>
+            <th class="sortable sorted" data-sort="articles" data-dir="desc">Country</th>
+            <th class="sortable" data-sort="articles" data-dir="desc">Articles</th>
+            <th class="sortable" data-sort="coverage" data-dir="desc">Coverage</th>
+            <th class="sortable" data-sort="crisis" data-dir="desc">Crisis Articles</th>
+            <th class="sortable" data-sort="ratio" data-dir="desc">Crisis Ratio</th>
+            <th class="sortable" data-sort="tone" data-dir="asc">Tone</th>
+          </tr>
+        </thead>
+        <tbody id="countryTbody"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script>
+const API='/api';
+const $=s=>document.querySelector(s);
+const $$=s=>document.querySelectorAll(s);
+
+Chart.defaults.color='#6e6e82';
+Chart.defaults.borderColor='rgba(34,34,48,0.6)';
+Chart.defaults.font.family="'DM Sans',sans-serif";
+
+const COUNTRIES={
+US:["United States","\u{1F1FA}\u{1F1F8}"],UK:["United Kingdom","\u{1F1EC}\u{1F1E7}"],
+CA:["Canada","\u{1F1E8}\u{1F1E6}"],AS:["Australia","\u{1F1E6}\u{1F1FA}"],
+FR:["France","\u{1F1EB}\u{1F1F7}"],GM:["Germany","\u{1F1E9}\u{1F1EA}"],
+IT:["Italy","\u{1F1EE}\u{1F1F9}"],SP:["Spain","\u{1F1EA}\u{1F1F8}"],
+JA:["Japan","\u{1F1EF}\u{1F1F5}"],CH:["China","\u{1F1E8}\u{1F1F3}"],
+IN:["India","\u{1F1EE}\u{1F1F3}"],RS:["Russia","\u{1F1F7}\u{1F1FA}"],
+BR:["Brazil","\u{1F1E7}\u{1F1F7}"],MX:["Mexico","\u{1F1F2}\u{1F1FD}"],
+IR:["Iran","\u{1F1EE}\u{1F1F7}"],IS:["Israel","\u{1F1EE}\u{1F1F1}"],
+SA:["Saudi Arabia","\u{1F1F8}\u{1F1E6}"],EG:["Egypt","\u{1F1EA}\u{1F1EC}"],
+TU:["Turkey","\u{1F1F9}\u{1F1F7}"],PK:["Pakistan","\u{1F1F5}\u{1F1F0}"],
+UP:["Ukraine","\u{1F1FA}\u{1F1E6}"],LE:["Lebanon","\u{1F1F1}\u{1F1E7}"],
+SY:["Syria","\u{1F1F8}\u{1F1FE}"],IZ:["Iraq","\u{1F1EE}\u{1F1F6}"],
+AF:["Afghanistan","\u{1F1E6}\u{1F1EB}"],KS:["South Korea","\u{1F1F0}\u{1F1F7}"],
+KN:["North Korea","\u{1F1F0}\u{1F1F5}"],TW:["Taiwan","\u{1F1F9}\u{1F1FC}"],
+TH:["Thailand","\u{1F1F9}\u{1F1ED}"],VM:["Vietnam","\u{1F1FB}\u{1F1F3}"],
+ID:["Indonesia","\u{1F1EE}\u{1F1E9}"],MY:["Malaysia","\u{1F1F2}\u{1F1FE}"],
+PL:["Poland","\u{1F1F5}\u{1F1F1}"],NL:["Netherlands","\u{1F1F3}\u{1F1F1}"],
+NI:["Nigeria","\u{1F1F3}\u{1F1EC}"],SF:["South Africa","\u{1F1FF}\u{1F1E6}"],
+KE:["Kenya","\u{1F1F0}\u{1F1EA}"],ET:["Ethiopia","\u{1F1EA}\u{1F1F9}"],
+GH:["Ghana","\u{1F1EC}\u{1F1ED}"],CO:["Colombia","\u{1F1E8}\u{1F1F4}"],
+AR:["Argentina","\u{1F1E6}\u{1F1F7}"],PE:["Peru","\u{1F1F5}\u{1F1EA}"],
+CU:["Cuba","\u{1F1E8}\u{1F1FA}"],QA:["Qatar","\u{1F1F6}\u{1F1E6}"],
+AE:["UAE","\u{1F1E6}\u{1F1EA}"],SU:["Sudan","\u{1F1F8}\u{1F1E9}"],
+LY:["Libya","\u{1F1F1}\u{1F1FE}"],MO:["Morocco","\u{1F1F2}\u{1F1E6}"],
+SN:["Senegal","\u{1F1F8}\u{1F1F3}"],UG:["Uganda","\u{1F1FA}\u{1F1EC}"],
+RO:["Romania","\u{1F1F7}\u{1F1F4}"],HU:["Hungary","\u{1F1ED}\u{1F1FA}"],
+EI:["Ireland","\u{1F1EE}\u{1F1EA}"],SZ:["Switzerland","\u{1F1E8}\u{1F1ED}"],
+SW:["Sweden","\u{1F1F8}\u{1F1EA}"],NO:["Norway","\u{1F1F3}\u{1F1F4}"],
+SO:["Somalia","\u{1F1F8}\u{1F1F4}"],YM:["Yemen","\u{1F1FE}\u{1F1EA}"],
+RP:["Philippines","\u{1F1F5}\u{1F1ED}"],BA:["Bahrain","\u{1F1E7}\u{1F1ED}"],
+JO:["Jordan","\u{1F1EF}\u{1F1F4}"],
+};
+
+function cName(code){return COUNTRIES[code]?COUNTRIES[code][0]:code}
+function cFlag(code){return COUNTRIES[code]?COUNTRIES[code][1]:''}
+function esc(s){const d=document.createElement('div');d.textContent=String(s);return d.innerHTML}
+function fmtDate(s){if(!s)return'';const d=new Date(s);return isNaN(d)?String(s):d.toLocaleDateString('en-US',{month:'short',day:'numeric'})}
+
+let _data=null;
+let _scatterChart=null;
+
+// ── Load ─────────────────────────────────────────
+
+async function loadData(){
+  try{
+    const data=await fetch(`${API}/asymmetry`).then(r=>{
+      if(!r.ok)throw new Error(`Server ${r.status}`);
+      return r.json();
+    });
+    _data=data;
+    renderOverview(data);
+    renderTreemap(data);
+    renderScatter(data);
+    renderStories(data);
+    renderTable(data);
+  }catch(e){
+    $('#treemap').innerHTML=`<div class="loading">${esc(e.message)}</div>`;
+  }
+}
+
+// ── Overview ─────────────────────────────────────
+
+function renderOverview(data){
+  $('#statTotal').textContent=data.total_articles.toLocaleString();
+  $('#statCountries').textContent=data.total_countries;
+
+  // Top 5 share
+  const top5=data.countries.slice(0,5);
+  const top5pct=top5.reduce((s,c)=>s+c.coverage_pct,0);
+  $('#statTopPct').textContent=top5pct.toFixed(1)+'%';
+
+  // Gini-like concentration (share of top 10% of countries)
+  const sorted=[...data.countries].sort((a,b)=>b.article_count-a.article_count);
+  const top10pct=sorted.slice(0,Math.max(1,Math.ceil(sorted.length*0.1)));
+  const top10share=top10pct.reduce((s,c)=>s+c.article_count,0)/data.total_articles*100;
+  $('#statGini').textContent=top10share.toFixed(0)+'%';
+}
+
+// ── Treemap ──────────────────────────────────────
+
+function renderTreemap(data){
+  const wrap=$('#treemap');
+  const W=wrap.clientWidth,H=wrap.clientHeight;
+  const items=data.countries.filter(c=>c.article_count>=50).slice(0,60);
+  const total=items.reduce((s,c)=>s+c.article_count,0);
+
+  // Simple squarified treemap layout
+  const rects=squarify(items.map(c=>c.article_count/total),W,H);
+
+  const maxCrisis=Math.max(...items.map(c=>c.crisis_ratio),0.01);
+
+  let html='';
+  rects.forEach((r,i)=>{
+    const c=items[i];
+    const crisisIntensity=c.crisis_ratio/maxCrisis;
+    // Color: neutral purple → red based on crisis ratio
+    const red=Math.round(124+131*crisisIntensity);
+    const green=Math.round(106-106*crisisIntensity);
+    const blue=Math.round(239-117*crisisIntensity);
+    const bg=`rgb(${red},${green},${blue})`;
+
+    const showLabel=r.w>40&&r.h>30;
+    const showCount=r.w>50&&r.h>44;
+
+    html+=`<div class="tm-cell" style="left:${r.x}px;top:${r.y}px;width:${r.w}px;height:${r.h}px;background:${bg}"
+      data-idx="${i}"
+      onmouseenter="showTmTip(event,${i})"
+      onmousemove="moveTip(event)"
+      onmouseleave="hideTip()">
+      ${showLabel?`<span class="tm-code">${c.code}</span>`:''}
+      ${showCount?`<span class="tm-count">${c.article_count.toLocaleString()}</span>`:''}
+    </div>`;
+  });
+
+  wrap.innerHTML=html;
+}
+
+// Simple squarified treemap algorithm
+function squarify(values,W,H){
+  const rects=[];
+  const areas=values.map(v=>v*W*H);
+  layoutRow(areas,0,0,W,H,rects);
+  return rects;
+}
+
+function layoutRow(areas,x,y,w,h,rects){
+  if(areas.length===0)return;
+  if(areas.length===1){
+    rects.push({x,y,w,h});
+    return;
+  }
+
+  const total=areas.reduce((s,a)=>s+a,0);
+  const horizontal=w>=h;
+  let row=[],rowArea=0,remaining=[...areas];
+  let bestAspect=Infinity;
+
+  for(let i=0;i<remaining.length;i++){
+    row.push(remaining[i]);
+    rowArea+=remaining[i];
+
+    const rowLen=horizontal?rowArea/h:rowArea/w;
+    let worstAspect=0;
+    for(const a of row){
+      const cellW=horizontal?rowLen:a/rowLen;
+      const cellH=horizontal?a/rowLen:rowLen;
+      const aspect=Math.max(cellW/cellH,cellH/cellW);
+      worstAspect=Math.max(worstAspect,aspect);
+    }
+
+    if(worstAspect>bestAspect&&row.length>1){
+      row.pop();rowArea-=remaining[i];
+      break;
+    }
+    bestAspect=worstAspect;
+  }
+
+  // Layout this row
+  const rowLen=horizontal?rowArea/h:rowArea/w;
+  let offset=0;
+  for(const a of row){
+    const cellLen=horizontal?a/rowLen:a/rowLen;
+    if(horizontal){
+      rects.push({x:x,y:y+offset,w:rowLen,h:cellLen});
+    }else{
+      rects.push({x:x+offset,y:y,w:cellLen,h:rowLen});
+    }
+    offset+=cellLen;
+  }
+
+  // Recurse with remaining
+  const rest=remaining.slice(row.length);
+  if(horizontal){
+    layoutRow(rest,x+rowLen,y,w-rowLen,h,rects);
+  }else{
+    layoutRow(rest,x,y+rowLen,w,h-rowLen,rects);
+  }
+}
+
+// ── Treemap tooltip ──────────────────────────────
+
+function showTmTip(e,idx){
+  const c=_data.countries.filter(c=>c.article_count>=50)[idx];
+  if(!c)return;
+  const tt=$('#tooltip');
+  tt.innerHTML=`
+    <div class="tooltip-name">${cFlag(c.code)} ${esc(cName(c.code))}</div>
+    <div class="tooltip-row"><span>Articles</span><span class="val">${c.article_count.toLocaleString()}</span></div>
+    <div class="tooltip-row"><span>Coverage</span><span class="val">${c.coverage_pct.toFixed(2)}%</span></div>
+    <div class="tooltip-row"><span>Crisis articles</span><span class="val">${c.crisis_articles.toLocaleString()}</span></div>
+    <div class="tooltip-row"><span>Crisis ratio</span><span class="val" style="color:${c.crisis_ratio>0.3?'var(--rose)':'var(--text-2)'}">${(c.crisis_ratio*100).toFixed(1)}%</span></div>
+  `;
+  tt.classList.add('visible');
+  moveTip(e);
+}
+
+function moveTip(e){
+  const tt=$('#tooltip');
+  tt.style.left=(e.clientX+16)+'px';
+  tt.style.top=(e.clientY-10)+'px';
+}
+
+function hideTip(){$('#tooltip').classList.remove('visible')}
+
+// ── Scatter chart ────────────────────────────────
+
+function renderScatter(data){
+  const items=data.countries.filter(c=>c.article_count>=20);
+
+  const ctx=$('#scatterChart').getContext('2d');
+  if(_scatterChart)_scatterChart.destroy();
+
+  _scatterChart=new Chart(ctx,{
+    type:'bubble',
+    data:{
+      datasets:[{
+        data:items.map(c=>({
+          x:c.article_count,
+          y:c.crisis_ratio*100,
+          r:Math.max(3,Math.min(18,Math.log10(c.article_count)*3)),
+          _code:c.code,
+          _name:cName(c.code),
+        })),
+        backgroundColor:items.map(c=>{
+          if(c.crisis_ratio>0.4)return'rgba(229,99,122,0.6)';
+          if(c.crisis_ratio>0.2)return'rgba(229,166,62,0.5)';
+          return'rgba(124,106,239,0.4)';
+        }),
+        borderColor:items.map(c=>{
+          if(c.crisis_ratio>0.4)return'rgba(229,99,122,0.9)';
+          if(c.crisis_ratio>0.2)return'rgba(229,166,62,0.8)';
+          return'rgba(124,106,239,0.7)';
+        }),
+        borderWidth:1,
+      }],
+    },
+    options:{
+      responsive:true,
+      maintainAspectRatio:false,
+      plugins:{
+        legend:{display:false},
+        tooltip:{
+          callbacks:{
+            label:ctx=>{
+              const p=ctx.raw;
+              return[`${p._name} (${p._code})`,`Articles: ${p.x.toLocaleString()}`,`Crisis ratio: ${p.y.toFixed(1)}%`];
+            },
+          },
+          backgroundColor:'rgba(12,12,16,0.95)',bodyColor:'#b0b0be',
+          borderColor:'rgba(255,255,255,0.08)',borderWidth:1,
+          padding:12,cornerRadius:10,
+        },
+      },
+      scales:{
+        x:{
+          type:'logarithmic',
+          title:{display:true,text:'Article Count (log scale)',color:'#6e6e82',font:{size:11}},
+          grid:{color:'rgba(34,34,48,0.4)'},
+        },
+        y:{
+          title:{display:true,text:'Crisis Ratio %',color:'#6e6e82',font:{size:11}},
+          grid:{color:'rgba(34,34,48,0.4)'},
+        },
+      },
+    },
+  });
+}
+
+// ── Stories ───────────────────────────────────────
+
+function renderStories(data){
+  // Overcovered
+  const overHtml=data.overcovered.map(c=>`
+    <div class="story-card">
+      <div class="story-title">${esc(c.title||'(untitled)')}</div>
+      <div class="story-meta">
+        <span class="story-badge badge-over">${c.article_count} articles</span>
+        <span>${fmtDate(c.first_article_at)} &mdash; ${fmtDate(c.last_article_at)}</span>
+      </div>
+    </div>
+  `).join('');
+  $('#overcoveredList').innerHTML=overHtml||'<div class="loading">No data</div>';
+
+  // Underreported
+  const underHtml=data.underreported.map(c=>`
+    <div class="story-card">
+      <div class="story-title">${esc(c.title||'(untitled)')}</div>
+      <div class="story-meta">
+        <span class="story-badge badge-under">${c.article_count} articles</span>
+        <span>${fmtDate(c.first_article_at)} &mdash; ${fmtDate(c.last_article_at)}</span>
+      </div>
+    </div>
+  `).join('');
+  $('#underreportedList').innerHTML=underHtml||'<div class="loading">No data</div>';
+}
+
+// ── Country table ────────────────────────────────
+
+let currentSort='articles',currentDir='desc';
+
+function renderTable(data){
+  const maxArticles=data.countries[0]?.article_count||1;
+  const maxCrisis=Math.max(...data.countries.map(c=>c.crisis_articles),1);
+
+  const sorted=[...data.countries];
+  sortCountries(sorted);
+
+  const html=sorted.slice(0,100).map(c=>{
+    const covW=Math.round(c.article_count/maxArticles*80);
+    const criW=Math.round(c.crisis_articles/maxCrisis*60);
+    const tCol=c.avg_tone<-1?'var(--rose)':c.avg_tone>1?'var(--teal)':'var(--text-3)';
+    return`<tr>
+      <td>${cFlag(c.code)} <strong>${esc(cName(c.code))}</strong> <span style="color:var(--text-3);font-size:0.7rem">${c.code}</span></td>
+      <td class="mono">${c.article_count.toLocaleString()}<span class="coverage-bar" style="width:${covW}px"></span></td>
+      <td class="mono">${c.coverage_pct.toFixed(2)}%</td>
+      <td class="mono">${c.crisis_articles.toLocaleString()}<span class="crisis-bar" style="width:${criW}px"></span></td>
+      <td class="mono" style="color:${c.crisis_ratio>0.3?'var(--rose)':'var(--text-2)'}">${(c.crisis_ratio*100).toFixed(1)}%</td>
+      <td class="mono" style="color:${tCol}">${c.avg_tone>0?'+':''}${c.avg_tone.toFixed(2)}</td>
+    </tr>`;
+  }).join('');
+
+  $('#countryTbody').innerHTML=html;
+}
+
+function sortCountries(arr){
+  const dir=currentDir==='desc'?-1:1;
+  const key={
+    articles:(c)=>c.article_count,
+    coverage:(c)=>c.coverage_pct,
+    crisis:(c)=>c.crisis_articles,
+    ratio:(c)=>c.crisis_ratio,
+    tone:(c)=>c.avg_tone,
+  }[currentSort]||(c=>c.article_count);
+
+  arr.sort((a,b)=>(key(a)-key(b))*dir);
+}
+
+// Table header sorting
+$$('.country-table th.sortable').forEach(th=>{
+  th.addEventListener('click',()=>{
+    const sort=th.dataset.sort;
+    if(currentSort===sort){
+      currentDir=currentDir==='desc'?'asc':'desc';
+    }else{
+      currentSort=sort;
+      currentDir=th.dataset.dir||'desc';
+    }
+    $$('.country-table th').forEach(h=>h.classList.remove('sorted'));
+    th.classList.add('sorted');
+    if(_data)renderTable(_data);
+  });
+});
+
+// ── Init ─────────────────────────────────────────
+
+loadData();
+</script>
+</body>
+</html>

--- a/src/gdelt_event_pipeline/api/static/gravity.html
+++ b/src/gdelt_event_pipeline/api/static/gravity.html
@@ -1,0 +1,743 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Geopolitical Gravity | GDELT Pulse</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+
+:root{
+  --bg:#050507;--bg-raised:#0c0c10;--surface:#111116;--surface-2:#17171d;
+  --surface-3:#1d1d25;--border:#222230;--border-dim:#1a1a24;
+  --text:#ededf0;--text-2:#b0b0be;--text-3:#6e6e82;
+  --primary:#7c6aef;--primary-light:#9d8ff5;--primary-dim:rgba(124,106,239,0.1);
+  --teal:#2dd4a8;--teal-dim:rgba(45,212,168,0.1);
+  --amber:#e5a63e;--amber-dim:rgba(229,166,62,0.1);
+  --rose:#e5637a;--rose-dim:rgba(229,99,122,0.1);
+  --glass-bg:rgba(17,17,22,0.4);--glass-border:rgba(255,255,255,0.06);
+  --ease:cubic-bezier(0.4,0,0.2,1);
+}
+
+body{
+  font-family:'DM Sans',-apple-system,sans-serif;
+  background:var(--bg);color:var(--text);
+  height:100vh;overflow:hidden;
+  -webkit-font-smoothing:antialiased;
+}
+
+::selection{background:var(--primary-dim);color:var(--primary-light)}
+
+/* ── Layout ───────────────────────────────────── */
+
+.app{display:flex;height:100vh}
+
+.graph-area{
+  flex:1;position:relative;overflow:hidden;
+}
+
+.sidebar{
+  width:380px;height:100vh;overflow-y:auto;
+  background:var(--bg-raised);
+  border-left:1px solid var(--border-dim);
+  display:flex;flex-direction:column;
+  transition:transform 0.35s var(--ease);
+}
+
+.sidebar.collapsed{transform:translateX(100%);width:0;min-width:0;border:none}
+
+.sidebar::-webkit-scrollbar{width:5px}
+.sidebar::-webkit-scrollbar-thumb{background:var(--border-dim);border-radius:3px}
+
+/* ── Top bar ──────────────────────────────────── */
+
+.topbar{
+  position:absolute;top:0;left:0;right:0;z-index:10;
+  display:flex;align-items:center;justify-content:space-between;
+  padding:16px 24px;
+  background:linear-gradient(180deg,rgba(5,5,7,0.9) 0%,transparent 100%);
+  pointer-events:none;
+}
+
+.topbar>*{pointer-events:auto}
+
+.topbar-left{display:flex;align-items:center;gap:16px}
+
+.topbar-back{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:7px 14px;border-radius:20px;
+  border:1px solid var(--border-dim);background:var(--glass-bg);
+  backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+  color:var(--text-2);font-size:0.78rem;font-family:inherit;
+  font-weight:500;cursor:pointer;text-decoration:none;
+  transition:all 0.2s var(--ease);
+}
+.topbar-back:hover{color:var(--text);border-color:var(--border)}
+.topbar-back svg{width:14px;height:14px}
+
+.topbar-title{
+  font-size:0.92rem;font-weight:600;letter-spacing:-0.02em;
+}
+.topbar-title .accent{color:var(--primary-light)}
+
+.topbar-controls{display:flex;align-items:center;gap:10px}
+
+.control-label{
+  font-size:0.7rem;color:var(--text-3);font-weight:500;
+  text-transform:uppercase;letter-spacing:0.06em;
+}
+
+.control-slider{
+  width:120px;accent-color:var(--primary);
+  cursor:pointer;
+}
+
+.control-val{
+  font-family:'JetBrains Mono',monospace;
+  font-size:0.72rem;color:var(--text-2);min-width:30px;
+}
+
+/* ── Graph SVG ────────────────────────────────── */
+
+.graph-svg{width:100%;height:100%;cursor:grab}
+.graph-svg:active{cursor:grabbing}
+
+.graph-svg .link{
+  stroke:rgba(124,106,239,0.15);
+  stroke-linecap:round;
+  transition:stroke 0.2s,stroke-opacity 0.2s;
+}
+
+.graph-svg .link.highlighted{
+  stroke:var(--primary-light);stroke-opacity:0.6;
+}
+
+.graph-svg .link.dimmed{stroke-opacity:0.04}
+
+.graph-svg .node-circle{
+  cursor:pointer;
+  transition:r 0.2s var(--ease),opacity 0.2s;
+}
+
+.graph-svg .node-circle.dimmed{opacity:0.15}
+
+.graph-svg .node-label{
+  font-family:'JetBrains Mono',monospace;
+  font-size:10px;font-weight:500;
+  fill:var(--text-2);
+  pointer-events:none;
+  text-anchor:middle;
+  transition:opacity 0.2s;
+}
+
+.graph-svg .node-label.dimmed{opacity:0.1}
+
+/* ── Tooltip ──────────────────────────────────── */
+
+.tooltip{
+  position:absolute;z-index:50;
+  background:rgba(12,12,16,0.95);
+  backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+  border:1px solid var(--glass-border);
+  border-radius:12px;padding:14px 16px;
+  pointer-events:none;opacity:0;
+  transition:opacity 0.15s;
+  max-width:260px;
+}
+
+.tooltip.visible{opacity:1}
+
+.tooltip-name{
+  font-size:0.88rem;font-weight:600;margin-bottom:4px;
+  letter-spacing:-0.01em;
+}
+
+.tooltip-row{
+  display:flex;justify-content:space-between;gap:16px;
+  font-size:0.74rem;color:var(--text-3);margin-bottom:2px;
+}
+
+.tooltip-row .val{
+  font-family:'JetBrains Mono',monospace;
+  color:var(--text-2);font-weight:500;
+}
+
+/* ── Sidebar content ──────────────────────────── */
+
+.sidebar-header{
+  padding:24px 24px 16px;
+  border-bottom:1px solid var(--border-dim);
+  position:sticky;top:0;z-index:2;
+  background:var(--bg-raised);
+}
+
+.sidebar-header h2{
+  font-size:1.05rem;font-weight:600;letter-spacing:-0.02em;
+  margin-bottom:2px;
+}
+
+.sidebar-header p{font-size:0.76rem;color:var(--text-3)}
+
+.sidebar-empty{
+  padding:48px 24px;text-align:center;
+  color:var(--text-3);font-size:0.84rem;
+}
+
+.sidebar-section{padding:20px 24px}
+
+.sidebar-section h3{
+  font-size:0.68rem;text-transform:uppercase;
+  letter-spacing:0.07em;color:var(--text-3);
+  font-weight:600;margin-bottom:12px;
+}
+
+/* Stats row */
+.detail-stats{display:flex;gap:8px;margin-bottom:20px}
+
+.d-stat{
+  flex:1;text-align:center;padding:12px 8px;
+  background:var(--surface);border:1px solid var(--border-dim);
+  border-radius:10px;
+}
+
+.d-stat-val{
+  font-family:'JetBrains Mono',monospace;
+  font-size:1rem;font-weight:600;margin-bottom:1px;
+}
+
+.d-stat-label{
+  font-size:0.58rem;text-transform:uppercase;
+  letter-spacing:0.06em;color:var(--text-3);font-weight:500;
+}
+
+/* Connection rows */
+.conn-row{
+  display:flex;align-items:center;gap:10px;
+  padding:9px 0;
+  border-bottom:1px solid rgba(34,34,48,0.3);
+  cursor:pointer;
+  transition:background 0.15s;
+  margin:0 -8px;padding-left:8px;padding-right:8px;
+  border-radius:8px;
+}
+
+.conn-row:last-child{border-bottom:none}
+.conn-row:hover{background:var(--surface)}
+
+.conn-flag{font-size:1.1rem;min-width:24px;text-align:center}
+
+.conn-name{
+  flex:1;font-size:0.82rem;font-weight:500;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+
+.conn-bar-wrap{width:80px;height:4px;background:var(--surface-3);border-radius:2px;overflow:hidden}
+
+.conn-bar{height:100%;border-radius:2px;background:var(--primary);transition:width 0.4s var(--ease)}
+
+.conn-val{
+  font-family:'JetBrains Mono',monospace;
+  font-size:0.7rem;color:var(--text-3);min-width:40px;
+  text-align:right;
+}
+
+/* Cluster cards in sidebar */
+.s-cluster{
+  padding:12px;background:var(--surface);
+  border:1px solid var(--border-dim);border-radius:10px;
+  margin-bottom:6px;transition:all 0.2s var(--ease);
+}
+
+.s-cluster:hover{border-color:rgba(124,106,239,0.3);background:var(--surface-2)}
+
+.s-cluster-title{
+  font-size:0.82rem;font-weight:500;line-height:1.35;
+  margin-bottom:4px;letter-spacing:-0.01em;
+}
+
+.s-cluster-meta{
+  font-size:0.7rem;color:var(--text-3);
+  display:flex;gap:10px;
+}
+
+.s-cluster-meta .mono{font-family:'JetBrains Mono',monospace}
+
+/* ── Legend ────────────────────────────────────── */
+
+.legend{
+  position:absolute;bottom:20px;left:20px;z-index:10;
+  background:var(--glass-bg);backdrop-filter:blur(16px);
+  -webkit-backdrop-filter:blur(16px);
+  border:1px solid var(--glass-border);
+  border-radius:12px;padding:14px 16px;
+  font-size:0.7rem;color:var(--text-3);
+}
+
+.legend-title{
+  font-size:0.62rem;text-transform:uppercase;
+  letter-spacing:0.07em;font-weight:600;margin-bottom:8px;
+  color:var(--text-3);
+}
+
+.legend-item{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+.legend-item:last-child{margin-bottom:0}
+
+.legend-circle{border-radius:50%;flex-shrink:0}
+
+/* ── Loading ──────────────────────────────────── */
+
+.loading-overlay{
+  position:absolute;inset:0;z-index:20;
+  display:flex;flex-direction:column;
+  align-items:center;justify-content:center;
+  background:var(--bg);
+  transition:opacity 0.4s;
+}
+
+.loading-overlay.hidden{opacity:0;pointer-events:none}
+
+.loading-text{
+  font-size:0.88rem;color:var(--text-3);margin-top:16px;
+}
+
+.spinner{
+  width:24px;height:24px;
+  border:2px solid var(--border);border-top-color:var(--primary);
+  border-radius:50%;animation:spin 0.6s linear infinite;
+}
+
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* ── Responsive ───────────────────────────────── */
+
+@media(max-width:768px){
+  .sidebar{
+    position:fixed;right:0;top:0;bottom:0;
+    width:320px;z-index:30;
+    box-shadow:-8px 0 32px rgba(0,0,0,0.5);
+  }
+  .topbar-controls{display:none}
+}
+</style>
+</head>
+<body>
+
+<div class="app">
+  <div class="graph-area">
+    <!-- Top bar -->
+    <div class="topbar">
+      <div class="topbar-left">
+        <a href="/" class="topbar-back">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+          Pulse
+        </a>
+        <span class="topbar-title">Geopolitical <span class="accent">Gravity</span></span>
+      </div>
+      <div class="topbar-controls">
+        <span class="control-label">Density</span>
+        <input type="range" class="control-slider" id="densitySlider" min="20" max="500" value="50" step="10">
+        <span class="control-val" id="densityVal">50</span>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div class="loading-overlay" id="loadingOverlay">
+      <div class="spinner"></div>
+      <div class="loading-text">Mapping geopolitical connections</div>
+    </div>
+
+    <!-- SVG graph -->
+    <svg class="graph-svg" id="graphSvg"></svg>
+
+    <!-- Tooltip -->
+    <div class="tooltip" id="tooltip"></div>
+
+    <!-- Legend -->
+    <div class="legend">
+      <div class="legend-title">Node Size = Coverage Volume</div>
+      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--teal)"></div><span>Positive avg tone</span></div>
+      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--text-3)"></div><span>Neutral tone</span></div>
+      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--rose)"></div><span>Negative avg tone</span></div>
+      <div class="legend-item" style="margin-top:6px"><div style="width:30px;height:2px;background:var(--primary);border-radius:1px"></div><span>Co-mention link</span></div>
+    </div>
+  </div>
+
+  <!-- Sidebar -->
+  <div class="sidebar collapsed" id="sidebar">
+    <div class="sidebar-header">
+      <h2 id="sidebarTitle">Select a country</h2>
+      <p id="sidebarSub">Click a node to explore</p>
+    </div>
+    <div id="sidebarBody">
+      <div class="sidebar-empty">Click any country node to see its geopolitical connections and top stories</div>
+    </div>
+  </div>
+</div>
+
+<script>
+const API='/api';
+const $=s=>document.querySelector(s);
+const $$=s=>document.querySelectorAll(s);
+
+// ── FIPS country code → name + flag ──────────────────
+
+const COUNTRIES={
+US:["United States","\u{1F1FA}\u{1F1F8}"],UK:["United Kingdom","\u{1F1EC}\u{1F1E7}"],
+CA:["Canada","\u{1F1E8}\u{1F1E6}"],AS:["Australia","\u{1F1E6}\u{1F1FA}"],
+FR:["France","\u{1F1EB}\u{1F1F7}"],GM:["Germany","\u{1F1E9}\u{1F1EA}"],
+IT:["Italy","\u{1F1EE}\u{1F1F9}"],SP:["Spain","\u{1F1EA}\u{1F1F8}"],
+JA:["Japan","\u{1F1EF}\u{1F1F5}"],CH:["China","\u{1F1E8}\u{1F1F3}"],
+IN:["India","\u{1F1EE}\u{1F1F3}"],RS:["Russia","\u{1F1F7}\u{1F1FA}"],
+BR:["Brazil","\u{1F1E7}\u{1F1F7}"],MX:["Mexico","\u{1F1F2}\u{1F1FD}"],
+IR:["Iran","\u{1F1EE}\u{1F1F7}"],IS:["Israel","\u{1F1EE}\u{1F1F1}"],
+SA:["Saudi Arabia","\u{1F1F8}\u{1F1E6}"],EG:["Egypt","\u{1F1EA}\u{1F1EC}"],
+TU:["Turkey","\u{1F1F9}\u{1F1F7}"],PK:["Pakistan","\u{1F1F5}\u{1F1F0}"],
+UP:["Ukraine","\u{1F1FA}\u{1F1E6}"],LE:["Lebanon","\u{1F1F1}\u{1F1E7}"],
+SY:["Syria","\u{1F1F8}\u{1F1FE}"],IZ:["Iraq","\u{1F1EE}\u{1F1F6}"],
+AF:["Afghanistan","\u{1F1E6}\u{1F1EB}"],KS:["South Korea","\u{1F1F0}\u{1F1F7}"],
+KN:["North Korea","\u{1F1F0}\u{1F1F5}"],TW:["Taiwan","\u{1F1F9}\u{1F1FC}"],
+TH:["Thailand","\u{1F1F9}\u{1F1ED}"],VM:["Vietnam","\u{1F1FB}\u{1F1F3}"],
+ID:["Indonesia","\u{1F1EE}\u{1F1E9}"],MY:["Malaysia","\u{1F1F2}\u{1F1FE}"],
+PL:["Poland","\u{1F1F5}\u{1F1F1}"],NL:["Netherlands","\u{1F1F3}\u{1F1F1}"],
+SW:["Sweden","\u{1F1F8}\u{1F1EA}"],NO:["Norway","\u{1F1F3}\u{1F1F4}"],
+DA:["Denmark","\u{1F1E9}\u{1F1F0}"],FI:["Finland","\u{1F1EB}\u{1F1EE}"],
+SZ:["Switzerland","\u{1F1E8}\u{1F1ED}"],AU:["Austria","\u{1F1E6}\u{1F1F9}"],
+BE:["Belgium","\u{1F1E7}\u{1F1EA}"],EI:["Ireland","\u{1F1EE}\u{1F1EA}"],
+PO:["Portugal","\u{1F1F5}\u{1F1F9}"],GR:["Greece","\u{1F1EC}\u{1F1F7}"],
+NI:["Nigeria","\u{1F1F3}\u{1F1EC}"],SF:["South Africa","\u{1F1FF}\u{1F1E6}"],
+KE:["Kenya","\u{1F1F0}\u{1F1EA}"],ET:["Ethiopia","\u{1F1EA}\u{1F1F9}"],
+GH:["Ghana","\u{1F1EC}\u{1F1ED}"],CO:["Colombia","\u{1F1E8}\u{1F1F4}"],
+AR:["Argentina","\u{1F1E6}\u{1F1F7}"],CI:["Chile","\u{1F1E8}\u{1F1F1}"],
+PE:["Peru","\u{1F1F5}\u{1F1EA}"],VE:["Venezuela","\u{1F1FB}\u{1F1EA}"],
+CU:["Cuba","\u{1F1E8}\u{1F1FA}"],RP:["Philippines","\u{1F1F5}\u{1F1ED}"],
+NZ:["New Zealand","\u{1F1F3}\u{1F1FF}"],QA:["Qatar","\u{1F1F6}\u{1F1E6}"],
+AE:["UAE","\u{1F1E6}\u{1F1EA}"],BA:["Bahrain","\u{1F1E7}\u{1F1ED}"],
+JO:["Jordan","\u{1F1EF}\u{1F1F4}"],GA:["Gambia","\u{1F1EC}\u{1F1F2}"],
+SU:["Sudan","\u{1F1F8}\u{1F1E9}"],LY:["Libya","\u{1F1F1}\u{1F1FE}"],
+MO:["Morocco","\u{1F1F2}\u{1F1E6}"],TS:["Tunisia","\u{1F1F9}\u{1F1F3}"],
+AG:["Algeria","\u{1F1E9}\u{1F1FF}"],SN:["Senegal","\u{1F1F8}\u{1F1F3}"],
+UG:["Uganda","\u{1F1FA}\u{1F1EC}"],RO:["Romania","\u{1F1F7}\u{1F1F4}"],
+HU:["Hungary","\u{1F1ED}\u{1F1FA}"],BU:["Bulgaria","\u{1F1E7}\u{1F1EC}"],
+HR:["Croatia","\u{1F1ED}\u{1F1F7}"],
+YM:["Yemen","\u{1F1FE}\u{1F1EA}"],
+SO:["Somalia","\u{1F1F8}\u{1F1F4}"],
+};
+
+function cName(code){return COUNTRIES[code]?COUNTRIES[code][0]:code}
+function cFlag(code){return COUNTRIES[code]?COUNTRIES[code][1]:"\u{1F310}"}
+function esc(s){const d=document.createElement('div');d.textContent=String(s);return d.innerHTML}
+
+function toneColor(t){
+  if(t<-1)return'#e5637a';
+  if(t>1)return'#2dd4a8';
+  return'#6e6e82';
+}
+
+// ── Graph state ──────────────────────────────────
+
+let sim,nodes=[],links=[],nodeMap={};
+let selectedNode=null;
+let svg,g,linkG,nodeG,labelG;
+let width,height;
+
+// ── Load & render ────────────────────────────────
+
+async function loadGraph(minWeight){
+  try{
+    const data=await fetch(`${API}/gravity/graph?min_weight=${minWeight}&limit_edges=100`).then(r=>{
+      if(!r.ok)throw new Error(`Server ${r.status}`);
+      return r.json();
+    });
+
+    nodes=data.nodes.map(n=>({...n,name:cName(n.id),flag:cFlag(n.id)}));
+    links=data.edges.map(e=>({source:e.source,target:e.target,weight:e.weight}));
+    nodeMap={};
+    nodes.forEach(n=>{nodeMap[n.id]=n});
+
+    buildGraph();
+    $('#loadingOverlay').classList.add('hidden');
+  }catch(e){
+    $('#loadingOverlay').querySelector('.loading-text').textContent=e.message;
+  }
+}
+
+function buildGraph(){
+  const container=$('#graphSvg');
+  const rect=container.getBoundingClientRect();
+  width=rect.width;height=rect.height;
+
+  // Clear
+  d3.select(container).selectAll('*').remove();
+
+  svg=d3.select(container)
+    .call(d3.zoom().scaleExtent([0.3,5]).on('zoom',e=>{
+      g.attr('transform',e.transform);
+    }));
+
+  g=svg.append('g');
+  linkG=g.append('g').attr('class','links');
+  nodeG=g.append('g').attr('class','nodes');
+  labelG=g.append('g').attr('class','labels');
+
+  // Scales
+  const maxArticles=d3.max(nodes,d=>d.article_count)||1;
+  const maxWeight=d3.max(links,d=>d.weight)||1;
+  const rScale=d3.scaleSqrt().domain([0,maxArticles]).range([6,40]);
+  const wScale=d3.scaleLinear().domain([0,maxWeight]).range([0.5,5]);
+
+  // Links
+  const link=linkG.selectAll('line').data(links).join('line')
+    .attr('class','link')
+    .attr('stroke-width',d=>wScale(d.weight));
+
+  // Nodes
+  const node=nodeG.selectAll('circle').data(nodes,d=>d.id).join('circle')
+    .attr('class','node-circle')
+    .attr('r',d=>rScale(d.article_count))
+    .attr('fill',d=>toneColor(d.avg_tone))
+    .attr('fill-opacity',0.7)
+    .attr('stroke',d=>toneColor(d.avg_tone))
+    .attr('stroke-width',1.5)
+    .attr('stroke-opacity',0.4)
+    .call(d3.drag()
+      .on('start',dragStart)
+      .on('drag',dragging)
+      .on('end',dragEnd))
+    .on('mouseover',(e,d)=>showTooltip(e,d))
+    .on('mousemove',(e)=>{moveTooltip(e)})
+    .on('mouseout',hideTooltip)
+    .on('click',(e,d)=>{
+      e.stopPropagation();
+      selectNode(d);
+    });
+
+  // Labels
+  const label=labelG.selectAll('text').data(nodes,d=>d.id).join('text')
+    .attr('class','node-label')
+    .attr('dy',d=>rScale(d.article_count)+14)
+    .text(d=>d.id);
+
+  // Simulation
+  sim=d3.forceSimulation(nodes)
+    .force('link',d3.forceLink(links).id(d=>d.id).distance(d=>{
+      const maxW=d3.max(links,l=>l.weight)||1;
+      return 180-120*(d.weight/maxW);
+    }).strength(d=>{
+      const maxW=d3.max(links,l=>l.weight)||1;
+      return 0.3+0.7*(d.weight/maxW);
+    }))
+    .force('charge',d3.forceManyBody().strength(-300))
+    .force('center',d3.forceCenter(width/2,height/2))
+    .force('collision',d3.forceCollide().radius(d=>rScale(d.article_count)+8))
+    .on('tick',()=>{
+      link
+        .attr('x1',d=>d.source.x)
+        .attr('y1',d=>d.source.y)
+        .attr('x2',d=>d.target.x)
+        .attr('y2',d=>d.target.y);
+      node
+        .attr('cx',d=>d.x)
+        .attr('cy',d=>d.y);
+      label
+        .attr('x',d=>d.x)
+        .attr('y',d=>d.y);
+    });
+
+  // Click background to deselect
+  svg.on('click',()=>{
+    clearSelection();
+  });
+}
+
+// ── Drag ─────────────────────────────────────────
+
+function dragStart(e,d){
+  if(!e.active)sim.alphaTarget(0.3).restart();
+  d.fx=d.x;d.fy=d.y;
+}
+
+function dragging(e,d){d.fx=e.x;d.fy=e.y}
+
+function dragEnd(e,d){
+  if(!e.active)sim.alphaTarget(0);
+  d.fx=null;d.fy=null;
+}
+
+// ── Tooltip ──────────────────────────────────────
+
+function showTooltip(e,d){
+  const tt=$('#tooltip');
+  const connCount=links.filter(l=>(l.source.id||l.source)===d.id||(l.target.id||l.target)===d.id).length;
+  tt.innerHTML=`
+    <div class="tooltip-name">${d.flag} ${esc(d.name)}</div>
+    <div class="tooltip-row"><span>Articles</span><span class="val">${d.article_count.toLocaleString()}</span></div>
+    <div class="tooltip-row"><span>Avg tone</span><span class="val" style="color:${toneColor(d.avg_tone)}">${d.avg_tone>0?'+':''}${d.avg_tone.toFixed(2)}</span></div>
+    <div class="tooltip-row"><span>Connections</span><span class="val">${connCount}</span></div>
+  `;
+  tt.classList.add('visible');
+  moveTooltip(e);
+}
+
+function moveTooltip(e){
+  const tt=$('#tooltip');
+  tt.style.left=(e.clientX+16)+'px';
+  tt.style.top=(e.clientY-10)+'px';
+}
+
+function hideTooltip(){$('#tooltip').classList.remove('visible')}
+
+// ── Node selection ───────────────────────────────
+
+function selectNode(d){
+  selectedNode=d;
+  const connIds=new Set();
+  links.forEach(l=>{
+    const sId=l.source.id||l.source;
+    const tId=l.target.id||l.target;
+    if(sId===d.id){connIds.add(tId)}
+    if(tId===d.id){connIds.add(sId)}
+  });
+
+  // Highlight graph
+  d3.selectAll('.link').each(function(l){
+    const sId=l.source.id||l.source;
+    const tId=l.target.id||l.target;
+    const connected=sId===d.id||tId===d.id;
+    d3.select(this).classed('highlighted',connected).classed('dimmed',!connected);
+  });
+
+  d3.selectAll('.node-circle').each(function(n){
+    const show=n.id===d.id||connIds.has(n.id);
+    d3.select(this).classed('dimmed',!show);
+    if(n.id===d.id){
+      d3.select(this).attr('stroke-width',3).attr('stroke-opacity',1);
+    }else{
+      d3.select(this).attr('stroke-width',1.5).attr('stroke-opacity',0.4);
+    }
+  });
+
+  d3.selectAll('.node-label').each(function(n){
+    d3.select(this).classed('dimmed',n.id!==d.id&&!connIds.has(n.id));
+  });
+
+  // Open sidebar
+  $('#sidebar').classList.remove('collapsed');
+  loadCountryDetail(d.id);
+}
+
+function clearSelection(){
+  selectedNode=null;
+  d3.selectAll('.link').classed('highlighted',false).classed('dimmed',false);
+  d3.selectAll('.node-circle').classed('dimmed',false)
+    .attr('stroke-width',1.5).attr('stroke-opacity',0.4);
+  d3.selectAll('.node-label').classed('dimmed',false);
+  $('#sidebar').classList.add('collapsed');
+}
+
+// ── Sidebar detail ───────────────────────────────
+
+async function loadCountryDetail(code){
+  const name=cName(code);
+  const flag=cFlag(code);
+  $('#sidebarTitle').textContent=`${flag} ${name}`;
+  $('#sidebarSub').textContent=`FIPS: ${code}`;
+  $('#sidebarBody').innerHTML='<div class="sidebar-empty"><div class="spinner"></div></div>';
+
+  try{
+    const d=await fetch(`${API}/gravity/country/${code}`).then(r=>{
+      if(!r.ok)throw new Error(`Server ${r.status}`);
+      return r.json();
+    });
+
+    const maxConn=d.connections.length?d.connections[0].weight:1;
+
+    let html=`
+      <div class="sidebar-section" style="padding-bottom:0">
+        <div class="detail-stats">
+          <div class="d-stat"><div class="d-stat-val">${d.article_count.toLocaleString()}</div><div class="d-stat-label">Articles</div></div>
+          <div class="d-stat"><div class="d-stat-val" style="color:${toneColor(d.avg_tone)}">${d.avg_tone>0?'+':''}${d.avg_tone.toFixed(2)}</div><div class="d-stat-label">Avg Tone</div></div>
+          <div class="d-stat"><div class="d-stat-val">${d.connections.length}</div><div class="d-stat-label">Connections</div></div>
+        </div>
+      </div>
+
+      <div class="sidebar-section">
+        <h3>Strongest Connections</h3>
+        ${d.connections.map(c=>{
+          const pct=Math.round(c.weight/maxConn*100);
+          return`<div class="conn-row" onclick="selectNodeById('${c.code}')">
+            <span class="conn-flag">${cFlag(c.code)}</span>
+            <span class="conn-name">${esc(cName(c.code))}</span>
+            <div class="conn-bar-wrap"><div class="conn-bar" style="width:${pct}%"></div></div>
+            <span class="conn-val">${c.weight.toLocaleString()}</span>
+          </div>`;
+        }).join('')}
+      </div>
+
+      <div class="sidebar-section">
+        <h3>Top Stories</h3>
+        ${d.top_clusters.map(c=>`
+          <div class="s-cluster">
+            <div class="s-cluster-title">${esc(c.title||'(untitled)')}</div>
+            <div class="s-cluster-meta">
+              <span><span class="mono">${c.mentions}</span> mentions</span>
+              <span><span class="mono">${c.article_count}</span> total articles</span>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    `;
+
+    $('#sidebarBody').innerHTML=html;
+
+    // Animate connection bars
+    setTimeout(()=>{
+      $$('.conn-bar').forEach(b=>{
+        const w=b.style.width;b.style.width='0';
+        requestAnimationFrame(()=>{b.style.width=w});
+      });
+    },50);
+
+  }catch(e){
+    $('#sidebarBody').innerHTML=`<div class="sidebar-empty">${esc(e.message)}</div>`;
+  }
+}
+
+function selectNodeById(code){
+  const n=nodeMap[code];
+  if(n)selectNode(n);
+}
+
+// ── Density slider ───────────────────────────────
+
+let debounceTimer;
+$('#densitySlider').addEventListener('input',()=>{
+  const v=$('#densitySlider').value;
+  $('#densityVal').textContent=v;
+  clearTimeout(debounceTimer);
+  debounceTimer=setTimeout(()=>{
+    $('#loadingOverlay').classList.remove('hidden');
+    loadGraph(parseInt(v));
+  },400);
+});
+
+// ── Resize ───────────────────────────────────────
+
+window.addEventListener('resize',()=>{
+  if(sim){
+    const rect=$('#graphSvg').getBoundingClientRect();
+    width=rect.width;height=rect.height;
+    sim.force('center',d3.forceCenter(width/2,height/2));
+    sim.alpha(0.3).restart();
+  }
+});
+
+// ── Init ─────────────────────────────────────────
+
+loadGraph(50);
+</script>
+</body>
+</html>

--- a/src/gdelt_event_pipeline/api/static/index.html
+++ b/src/gdelt_event_pipeline/api/static/index.html
@@ -899,6 +899,30 @@ body {
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           Search Events
         </button>
+        <button class="hero-btn hero-btn-glass" onclick="location.href='/polarization'">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M2 12h20"/><circle cx="12" cy="12" r="10"/></svg>
+          Polarization
+        </button>
+        <button class="hero-btn hero-btn-glass" onclick="location.href='/gravity'">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          Gravity Map
+        </button>
+        <button class="hero-btn hero-btn-glass" onclick="location.href='/asymmetry'">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+          Asymmetry
+        </button>
+        <button class="hero-btn hero-btn-glass" onclick="location.href='/sources'">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/><path d="M12 6v6l4 2"/></svg>
+          Source DNA
+        </button>
+        <button class="hero-btn hero-btn-glass" onclick="location.href='/propagation'">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          Propagation
+        </button>
+        <button class="hero-btn hero-btn-glass" onclick="location.href='/velocity'">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+          Topic Velocity
+        </button>
       </div>
     </section>
 

--- a/src/gdelt_event_pipeline/api/static/polarization.html
+++ b/src/gdelt_event_pipeline/api/static/polarization.html
@@ -1,0 +1,913 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Narrative Polarization | GDELT Pulse</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+
+:root {
+  --bg: #050507;
+  --bg-raised: #0c0c10;
+  --surface: #111116;
+  --surface-2: #17171d;
+  --surface-3: #1d1d25;
+  --border: #222230;
+  --border-dim: #1a1a24;
+  --text: #ededf0;
+  --text-2: #b0b0be;
+  --text-3: #6e6e82;
+  --primary: #7c6aef;
+  --primary-light: #9d8ff5;
+  --primary-dim: rgba(124, 106, 239, 0.1);
+  --primary-glow: rgba(124, 106, 239, 0.06);
+  --teal: #2dd4a8;
+  --teal-dim: rgba(45, 212, 168, 0.1);
+  --amber: #e5a63e;
+  --amber-dim: rgba(229, 166, 62, 0.1);
+  --rose: #e5637a;
+  --rose-dim: rgba(229, 99, 122, 0.1);
+  --negative: #e5637a;
+  --positive: #2dd4a8;
+  --glass-bg: rgba(17, 17, 22, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.06);
+  --glass-blur: 20px;
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+  font-family: 'DM Sans', -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+::selection { background: var(--primary-dim); color: var(--primary-light); }
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 3px; }
+
+/* ── Top bar ──────────────────────────────────────── */
+
+.topbar {
+  position: fixed; top: 0; left: 0; right: 0;
+  z-index: 100;
+  display: flex; align-items: center; gap: 16px;
+  padding: 14px 24px;
+  background: rgba(5, 5, 7, 0.8);
+  backdrop-filter: blur(20px) saturate(1.6);
+  -webkit-backdrop-filter: blur(20px) saturate(1.6);
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.topbar-back {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 20px;
+  border: 1px solid var(--border-dim); background: none;
+  color: var(--text-2); font-size: 0.78rem; font-family: inherit;
+  font-weight: 500; cursor: pointer; text-decoration: none;
+  transition: all 0.2s var(--ease);
+}
+.topbar-back:hover { color: var(--text); border-color: var(--border); }
+.topbar-back svg { width: 14px; height: 14px; }
+
+.topbar-title {
+  font-size: 0.9rem; font-weight: 600; letter-spacing: -0.02em;
+}
+.topbar-title .accent { color: var(--primary-light); }
+
+/* ── Page layout ──────────────────────────────────── */
+
+.page-wrap {
+  max-width: 1000px; margin: 0 auto;
+  padding: 80px 24px 60px;
+}
+
+.page-intro {
+  text-align: center; margin-bottom: 40px;
+  animation: fadeUp 0.6s var(--ease) both;
+}
+
+.page-intro h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700; letter-spacing: -0.04em;
+  margin-bottom: 10px;
+}
+
+.page-intro h1 .accent {
+  background: linear-gradient(135deg, var(--negative), var(--primary-light), var(--positive));
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-intro p {
+  font-size: 0.92rem; color: var(--text-3);
+  max-width: 540px; margin: 0 auto;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(18px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Overview stats ───────────────────────────────── */
+
+.overview-stats {
+  display: flex; gap: 10px; margin-bottom: 32px;
+  animation: fadeUp 0.6s var(--ease) 0.1s both;
+}
+
+.ov-stat {
+  flex: 1; text-align: center; padding: 18px 14px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  border-radius: 14px;
+}
+
+.ov-stat-val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.4rem; font-weight: 600; margin-bottom: 2px;
+}
+
+.ov-stat-label {
+  font-size: 0.66rem; text-transform: uppercase;
+  letter-spacing: 0.07em; color: var(--text-3); font-weight: 500;
+}
+
+/* ── Overview chart ───────────────────────────────── */
+
+.overview-chart-wrap {
+  background: var(--surface); border: 1px solid var(--border-dim);
+  border-radius: 16px; padding: 24px; margin-bottom: 36px;
+  animation: fadeUp 0.6s var(--ease) 0.15s both;
+}
+
+.overview-chart-wrap h3 {
+  font-size: 0.78rem; text-transform: uppercase;
+  letter-spacing: 0.07em; color: var(--text-3);
+  font-weight: 600; margin-bottom: 16px;
+}
+
+.chart-container { position: relative; height: 220px; }
+
+/* ── Polarization cards ───────────────────────────── */
+
+.section-label {
+  font-size: 0.72rem; text-transform: uppercase;
+  letter-spacing: 0.08em; color: var(--text-3);
+  font-weight: 600; margin-bottom: 14px;
+  animation: fadeUp 0.6s var(--ease) 0.2s both;
+}
+
+.pol-card {
+  background: var(--surface); border: 1px solid var(--border-dim);
+  border-radius: 16px; padding: 22px 24px; margin-bottom: 10px;
+  cursor: pointer; transition: all 0.25s var(--ease);
+  animation: fadeUp 0.4s var(--ease) both;
+}
+
+.pol-card:hover {
+  border-color: rgba(124, 106, 239, 0.4);
+  background: var(--surface-2);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.25);
+  transform: translateY(-2px);
+}
+
+.pol-card-top {
+  display: flex; justify-content: space-between;
+  align-items: flex-start; gap: 16px; margin-bottom: 10px;
+}
+
+.pol-card-title {
+  font-size: 0.94rem; font-weight: 500; line-height: 1.4;
+  letter-spacing: -0.01em; flex: 1;
+}
+
+.pol-score {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem; font-weight: 600;
+  padding: 5px 12px; border-radius: 20px;
+  white-space: nowrap; flex-shrink: 0;
+}
+
+.pol-score-high { color: var(--negative); background: var(--rose-dim); }
+.pol-score-med { color: var(--amber); background: var(--amber-dim); }
+.pol-score-low { color: var(--teal); background: var(--teal-dim); }
+
+.pol-card-meta {
+  display: flex; gap: 16px; font-size: 0.76rem;
+  color: var(--text-3); margin-bottom: 12px;
+}
+
+.pol-card-meta .mono {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ── Tone bar ─────────────────────────────────────── */
+
+.tone-bar-wrap {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 8px;
+}
+
+.tone-bar-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.66rem; color: var(--text-3);
+  min-width: 34px; text-align: right;
+}
+
+.tone-bar-label.pos { color: var(--positive); }
+.tone-bar-label.neg { color: var(--negative); }
+
+.tone-bar-track {
+  flex: 1; height: 6px; background: var(--surface-3);
+  border-radius: 3px; position: relative; overflow: hidden;
+}
+
+.tone-bar-fill {
+  position: absolute; top: 0; height: 100%; border-radius: 3px;
+}
+
+.tone-bar-avg {
+  position: absolute; top: -3px; width: 3px; height: 12px;
+  background: var(--text); border-radius: 1px;
+  transform: translateX(-50%);
+}
+
+/* ── Source mini-bars ──────────────────────────────── */
+
+.source-bars { margin-top: 6px; }
+
+.src-row {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 3px;
+}
+
+.src-name {
+  font-size: 0.7rem; color: var(--text-3);
+  min-width: 110px; max-width: 110px;
+  white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis; text-align: right;
+}
+
+.src-bar-track {
+  flex: 1; height: 4px; background: var(--surface-3);
+  border-radius: 2px; position: relative;
+}
+
+.src-bar-fill {
+  position: absolute; top: 0; height: 100%; border-radius: 2px;
+}
+
+.src-tone {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.64rem; min-width: 36px;
+}
+
+.src-tone.pos { color: var(--positive); }
+.src-tone.neg { color: var(--negative); }
+
+/* ── Detail modal ─────────────────────────────────── */
+
+.overlay {
+  display: none; position: fixed; inset: 0;
+  background: rgba(5, 5, 7, 0.88);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  z-index: 200; align-items: flex-start;
+  justify-content: center; padding: 24px;
+  overflow-y: auto;
+}
+
+.overlay.open { display: flex; animation: fadeIn 0.2s ease; }
+
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+.detail-panel {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  width: 100%; max-width: 820px;
+  padding: 32px; margin: 40px 0;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.5);
+  animation: modalIn 0.25s var(--ease);
+}
+
+@keyframes modalIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.detail-panel::-webkit-scrollbar { width: 5px; }
+.detail-panel::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 3px; }
+
+.detail-close {
+  float: right; width: 32px; height: 32px; border-radius: 10px;
+  border: 1px solid var(--border-dim); background: var(--surface);
+  color: var(--text-3); font-size: 1rem; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.15s;
+}
+.detail-close:hover { color: var(--text); border-color: var(--border); }
+
+.detail-title {
+  font-size: 1.15rem; font-weight: 600; margin-bottom: 6px;
+  padding-right: 44px; letter-spacing: -0.02em;
+}
+
+.detail-meta {
+  font-size: 0.78rem; color: var(--text-3); margin-bottom: 20px;
+}
+
+.detail-stats {
+  display: flex; gap: 10px; margin-bottom: 24px;
+}
+
+.detail-stat {
+  flex: 1; text-align: center; padding: 14px 10px;
+  background: var(--surface); border: 1px solid var(--border-dim);
+  border-radius: 12px;
+}
+
+.detail-stat-val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.1rem; font-weight: 600; margin-bottom: 2px;
+}
+
+.detail-stat-label {
+  font-size: 0.62rem; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-3); font-weight: 500;
+}
+
+.detail-section {
+  margin-bottom: 24px;
+}
+
+.detail-section h3 {
+  font-size: 0.72rem; text-transform: uppercase;
+  letter-spacing: 0.07em; color: var(--text-3);
+  font-weight: 600; margin-bottom: 12px;
+}
+
+.detail-chart { position: relative; height: 200px; margin-bottom: 8px; }
+
+/* ── Source groups in detail ──────────────────────── */
+
+.source-group {
+  margin-bottom: 16px; padding: 16px;
+  background: var(--surface); border: 1px solid var(--border-dim);
+  border-radius: 12px;
+}
+
+.source-group-header {
+  display: flex; justify-content: space-between;
+  align-items: center; margin-bottom: 10px;
+  cursor: pointer;
+}
+
+.source-group-name {
+  font-size: 0.86rem; font-weight: 500;
+}
+
+.source-group-meta {
+  display: flex; gap: 12px; align-items: center;
+}
+
+.source-group-tone {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem; font-weight: 600;
+}
+
+.source-group-count {
+  font-size: 0.72rem; color: var(--text-3);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.source-articles { margin-top: 8px; }
+
+.source-article {
+  padding: 8px 0;
+  border-top: 1px solid var(--border-dim);
+  display: flex; justify-content: space-between;
+  align-items: flex-start; gap: 12px;
+}
+
+.source-article:first-child { border-top: none; padding-top: 0; }
+
+.source-article-title {
+  font-size: 0.82rem; flex: 1;
+}
+
+.source-article-title a {
+  color: var(--text-2); text-decoration: none;
+  transition: color 0.15s;
+}
+.source-article-title a:hover { color: var(--primary-light); }
+
+.source-article-tone {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.74rem; white-space: nowrap;
+}
+
+/* ── Loading / empty states ───────────────────────── */
+
+.loading, .empty-state {
+  text-align: center; padding: 48px 20px;
+  color: var(--text-3); font-size: 0.86rem;
+}
+
+.spinner {
+  display: inline-block; width: 16px; height: 16px;
+  border: 2px solid var(--border); border-top-color: var(--primary);
+  border-radius: 50%; animation: spin 0.5s linear infinite;
+  margin-left: 8px; vertical-align: middle;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Responsive ───────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .page-wrap { padding: 72px 14px 40px; }
+  .overview-stats { flex-direction: column; }
+  .detail-stats { flex-wrap: wrap; }
+  .detail-stat { flex: 1 1 calc(50% - 5px); }
+  .pol-card-top { flex-direction: column; gap: 6px; }
+  .src-name { min-width: 80px; max-width: 80px; }
+}
+</style>
+</head>
+<body>
+
+<!-- Top bar -->
+<div class="topbar">
+  <a href="/" class="topbar-back">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+  <span class="topbar-title">Narrative <span class="accent">Polarization</span></span>
+</div>
+
+<!-- Page content -->
+<div class="page-wrap">
+  <div class="page-intro">
+    <h1>Narrative <span class="accent">Polarization</span></h1>
+    <p>Stories where the world disagrees on what happened. High polarization = same event, opposite framing across sources.</p>
+  </div>
+
+  <!-- Overview stats -->
+  <div class="overview-stats">
+    <div class="ov-stat"><div class="ov-stat-val" id="statStories">--</div><div class="ov-stat-label">Polarized Stories</div></div>
+    <div class="ov-stat"><div class="ov-stat-val" id="statAvgScore">--</div><div class="ov-stat-label">Avg Polarization</div></div>
+    <div class="ov-stat"><div class="ov-stat-val" id="statMaxScore">--</div><div class="ov-stat-label">Max Polarization</div></div>
+    <div class="ov-stat"><div class="ov-stat-val" id="statSources">--</div><div class="ov-stat-label">Avg Sources/Story</div></div>
+  </div>
+
+  <!-- Overview scatter chart: polarization vs article count -->
+  <div class="overview-chart-wrap">
+    <h3>Polarization Score Distribution</h3>
+    <div class="chart-container"><canvas id="overviewChart"></canvas></div>
+  </div>
+
+  <!-- Story list -->
+  <div class="section-label">Most Polarized Stories</div>
+  <div id="storyList"><div class="loading">Analyzing narrative polarization<span class="spinner"></span></div></div>
+</div>
+
+<!-- Detail overlay -->
+<div class="overlay" id="overlay">
+  <div class="detail-panel" id="detailPanel">
+    <button class="detail-close" id="detailClose">&times;</button>
+    <h2 class="detail-title" id="detailTitle"></h2>
+    <div class="detail-meta" id="detailMeta"></div>
+    <div class="detail-stats" id="detailStats"></div>
+    <div class="detail-section">
+      <h3>Tone Distribution</h3>
+      <div class="detail-chart"><canvas id="detailHistChart"></canvas></div>
+    </div>
+    <div class="detail-section">
+      <h3>Tone by Source</h3>
+      <div class="detail-chart" id="detailSourceChartWrap" style="height:auto;min-height:200px"><canvas id="detailSourceChart"></canvas></div>
+    </div>
+    <div class="detail-section">
+      <h3>Source Breakdown</h3>
+      <div id="detailSources"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+const API = '/api';
+const $ = s => document.querySelector(s);
+const $$ = s => document.querySelectorAll(s);
+
+// Chart.js global config
+Chart.defaults.color = '#6e6e82';
+Chart.defaults.borderColor = 'rgba(34,34,48,0.6)';
+Chart.defaults.font.family = "'DM Sans', sans-serif";
+
+let _data = [];
+let _overviewChart = null;
+let _detailHistChart = null;
+let _detailSourceChart = null;
+
+function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+
+function fmtDate(s) {
+  if (!s) return '';
+  const d = new Date(s);
+  return isNaN(d) ? String(s) : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function toneColor(t) {
+  if (t < -1) return 'var(--negative)';
+  if (t > 1) return 'var(--positive)';
+  return 'var(--text-3)';
+}
+
+function toneColorRgba(t, alpha) {
+  if (t < -1) return `rgba(229, 99, 122, ${alpha})`;
+  if (t > 1) return `rgba(45, 212, 168, ${alpha})`;
+  return `rgba(110, 110, 130, ${alpha})`;
+}
+
+function scoreClass(s) {
+  if (s >= 3.5) return 'pol-score-high';
+  if (s >= 2.5) return 'pol-score-med';
+  return 'pol-score-low';
+}
+
+// ── Load data ────────────────────────────────────────────
+
+async function loadData() {
+  try {
+    const data = await fetch(`${API}/polarization?limit=30&min_articles=20`).then(r => {
+      if (!r.ok) throw new Error(`Server error ${r.status}`);
+      return r.json();
+    });
+    _data = data;
+    renderOverview(data);
+    renderStories(data);
+  } catch (e) {
+    $('#storyList').innerHTML = `<div class="empty-state">${esc(e.message)}</div>`;
+  }
+}
+
+// ── Overview ─────────────────────────────────────────────
+
+function renderOverview(data) {
+  if (!data.length) return;
+
+  const scores = data.map(d => d.polarization_score);
+  const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const maxScore = Math.max(...scores);
+  const avgSources = data.reduce((a, d) => a + d.distinct_sources, 0) / data.length;
+
+  $('#statStories').textContent = data.length;
+  $('#statAvgScore').textContent = avgScore.toFixed(2);
+  $('#statMaxScore').textContent = maxScore.toFixed(2);
+  $('#statSources').textContent = Math.round(avgSources);
+
+  // Scatter: polarization score vs article count
+  const ctx = $('#overviewChart').getContext('2d');
+  if (_overviewChart) _overviewChart.destroy();
+
+  _overviewChart = new Chart(ctx, {
+    type: 'bubble',
+    data: {
+      datasets: [{
+        data: data.map(d => ({
+          x: d.article_count,
+          y: d.polarization_score,
+          r: Math.max(4, Math.min(16, d.distinct_sources / 2)),
+          _title: d.title,
+          _id: d.id,
+        })),
+        backgroundColor: data.map(d => toneColorRgba(d.avg_tone < 0 ? -2 : 2, 0.5)),
+        borderColor: data.map(d => toneColorRgba(d.avg_tone < 0 ? -2 : 2, 0.8)),
+        borderWidth: 1,
+      }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: ctx => {
+              const p = ctx.raw;
+              const title = p._title || '';
+              const short = title.length > 60 ? title.slice(0, 57) + '...' : title;
+              return [short, `Polarization: ${p.y.toFixed(2)}`, `Articles: ${p.x}`];
+            },
+          },
+          backgroundColor: 'rgba(12,12,16,0.95)',
+          titleColor: '#ededf0',
+          bodyColor: '#b0b0be',
+          borderColor: 'rgba(255,255,255,0.08)',
+          borderWidth: 1,
+          padding: 12,
+          cornerRadius: 10,
+        },
+      },
+      scales: {
+        x: {
+          title: { display: true, text: 'Article Count', color: '#6e6e82', font: { size: 11 } },
+          grid: { color: 'rgba(34,34,48,0.4)' },
+        },
+        y: {
+          title: { display: true, text: 'Polarization Score', color: '#6e6e82', font: { size: 11 } },
+          grid: { color: 'rgba(34,34,48,0.4)' },
+        },
+      },
+      onClick: (e, elements) => {
+        if (elements.length) {
+          const idx = elements[0].index;
+          const id = _data[idx].id;
+          openDetail(id);
+        }
+      },
+    },
+  });
+}
+
+// ── Story cards ──────────────────────────────────────────
+
+function renderStories(data) {
+  if (!data.length) {
+    $('#storyList').innerHTML = '<div class="empty-state">No polarized stories found</div>';
+    return;
+  }
+
+  const html = data.map((d, i) => {
+    const delay = `style="animation-delay:${Math.min(i, 20) * 40}ms"`;
+
+    // Tone bar: map range [-10, 10] to [0%, 100%]
+    const minPct = Math.max(0, (d.tone_min + 10) / 20 * 100);
+    const maxPct = Math.min(100, (d.tone_max + 10) / 20 * 100);
+    const avgPct = Math.max(0, Math.min(100, (d.avg_tone + 10) / 20 * 100));
+
+    // Source bars (top 5)
+    const srcHtml = d.sources.slice(0, 5).map(s => {
+      const pct = Math.max(0, Math.min(100, (s.avg_tone + 10) / 20 * 100));
+      const col = toneColor(s.avg_tone);
+      const cls = s.avg_tone >= 0 ? 'pos' : 'neg';
+      return `<div class="src-row">
+        <span class="src-name" title="${esc(s.source)}">${esc(s.source)}</span>
+        <div class="src-bar-track">
+          <div class="src-bar-fill" style="left:50%;width:${Math.abs(pct - 50)}%;${pct < 50 ? `right:50%;left:auto;` : ''}background:${col}"></div>
+        </div>
+        <span class="src-tone ${cls}">${s.avg_tone > 0 ? '+' : ''}${s.avg_tone.toFixed(1)}</span>
+      </div>`;
+    }).join('');
+
+    return `<div class="pol-card" data-id="${d.id}" ${delay} onclick="openDetail('${d.id}')">
+      <div class="pol-card-top">
+        <span class="pol-card-title">${esc(d.title || '(untitled)')}</span>
+        <span class="pol-score ${scoreClass(d.polarization_score)}">${d.polarization_score.toFixed(2)}</span>
+      </div>
+      <div class="pol-card-meta">
+        <span><span class="mono">${d.article_count}</span> articles</span>
+        <span><span class="mono">${d.distinct_sources}</span> sources</span>
+        <span>avg tone <span class="mono" style="color:${toneColor(d.avg_tone)}">${d.avg_tone > 0 ? '+' : ''}${d.avg_tone.toFixed(2)}</span></span>
+        <span>${fmtDate(d.first_article_at)} &mdash; ${fmtDate(d.last_article_at)}</span>
+      </div>
+      <div class="tone-bar-wrap">
+        <span class="tone-bar-label neg">${d.tone_min.toFixed(1)}</span>
+        <div class="tone-bar-track">
+          <div class="tone-bar-fill" style="left:${minPct}%;width:${maxPct - minPct}%;background:linear-gradient(90deg, var(--negative), var(--text-3) 50%, var(--positive))"></div>
+          <div class="tone-bar-avg" style="left:${avgPct}%"></div>
+        </div>
+        <span class="tone-bar-label pos">+${d.tone_max.toFixed(1)}</span>
+      </div>
+      <div class="source-bars">${srcHtml}</div>
+    </div>`;
+  }).join('');
+
+  $('#storyList').innerHTML = html;
+}
+
+// ── Detail view ──────────────────────────────────────────
+
+async function openDetail(id) {
+  const overlay = $('#overlay');
+  overlay.classList.add('open');
+  document.body.style.overflow = 'hidden';
+
+  $('#detailTitle').textContent = 'Loading...';
+  $('#detailMeta').textContent = '';
+  $('#detailStats').innerHTML = '<div class="loading"><span class="spinner"></span></div>';
+  $('#detailSources').innerHTML = '';
+
+  try {
+    const d = await fetch(`${API}/polarization/${id}`).then(r => {
+      if (!r.ok) throw new Error(`Server error ${r.status}`);
+      return r.json();
+    });
+
+    $('#detailTitle').textContent = d.cluster.title || '(untitled)';
+    $('#detailMeta').innerHTML = `${d.total_articles_with_tone} articles with tone data &middot; ${fmtDate(d.cluster.first_article_at)} &mdash; ${fmtDate(d.cluster.last_article_at)}`;
+
+    // Stats
+    $('#detailStats').innerHTML = `
+      <div class="detail-stat"><div class="detail-stat-val" style="color:var(--primary-light)">${d.polarization_score.toFixed(2)}</div><div class="detail-stat-label">Polarization</div></div>
+      <div class="detail-stat"><div class="detail-stat-val" style="color:${toneColor(d.avg_tone)}">${d.avg_tone > 0 ? '+' : ''}${d.avg_tone.toFixed(2)}</div><div class="detail-stat-label">Avg Tone</div></div>
+      <div class="detail-stat"><div class="detail-stat-val" style="color:var(--negative)">${d.tone_min.toFixed(1)}</div><div class="detail-stat-label">Most Negative</div></div>
+      <div class="detail-stat"><div class="detail-stat-val" style="color:var(--positive)">+${d.tone_max.toFixed(1)}</div><div class="detail-stat-label">Most Positive</div></div>
+      <div class="detail-stat"><div class="detail-stat-val">${d.sources.length}</div><div class="detail-stat-label">Sources</div></div>
+    `;
+
+    // Histogram from precomputed data or from articles
+    renderDetailHistogram(d);
+    renderDetailSourceChart(d);
+    renderDetailSources(d);
+
+  } catch (e) {
+    $('#detailStats').innerHTML = `<div class="empty-state">${esc(e.message)}</div>`;
+  }
+}
+
+function renderDetailHistogram(d) {
+  // Build histogram from all articles
+  const allTones = [];
+  d.sources.forEach(s => s.articles.forEach(a => { if (a.tone != null) allTones.push(a.tone); }));
+
+  const bucketSize = 1;
+  const buckets = {};
+  for (let i = -10; i < 10; i++) buckets[i] = 0;
+  allTones.forEach(t => {
+    const b = Math.max(-10, Math.min(9, Math.floor(t)));
+    buckets[b] = (buckets[b] || 0) + 1;
+  });
+
+  const labels = Object.keys(buckets).map(Number).sort((a, b) => a - b);
+  const values = labels.map(l => buckets[l]);
+  const colors = labels.map(l => {
+    if (l < -1) return 'rgba(229, 99, 122, 0.7)';
+    if (l > 0) return 'rgba(45, 212, 168, 0.7)';
+    return 'rgba(110, 110, 130, 0.5)';
+  });
+
+  const ctx = $('#detailHistChart').getContext('2d');
+  if (_detailHistChart) _detailHistChart.destroy();
+
+  _detailHistChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: labels.map(l => l.toString()),
+      datasets: [{
+        data: values,
+        backgroundColor: colors,
+        borderRadius: 3,
+        barPercentage: 0.95,
+        categoryPercentage: 1,
+      }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title: ctx => `Tone ${ctx[0].label} to ${Number(ctx[0].label) + 1}`,
+            label: ctx => `${ctx.raw} articles`,
+          },
+          backgroundColor: 'rgba(12,12,16,0.95)',
+          bodyColor: '#b0b0be',
+          borderColor: 'rgba(255,255,255,0.08)',
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 8,
+        },
+      },
+      scales: {
+        x: {
+          title: { display: true, text: 'Tone Score', color: '#6e6e82', font: { size: 11 } },
+          grid: { display: false },
+        },
+        y: {
+          title: { display: true, text: 'Articles', color: '#6e6e82', font: { size: 11 } },
+          grid: { color: 'rgba(34,34,48,0.4)' },
+        },
+      },
+    },
+  });
+}
+
+function renderDetailSourceChart(d) {
+  // Horizontal bar: one bar per source, colored by tone
+  const sources = d.sources.filter(s => s.article_count >= 2).slice(0, 20);
+
+  const chartHeight = Math.max(200, sources.length * 28 + 40);
+  $('#detailSourceChartWrap').style.height = chartHeight + 'px';
+
+  const ctx = $('#detailSourceChart').getContext('2d');
+  if (_detailSourceChart) _detailSourceChart.destroy();
+
+  _detailSourceChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: sources.map(s => {
+        const name = s.source;
+        return name.length > 25 ? name.slice(0, 22) + '...' : name;
+      }),
+      datasets: [{
+        data: sources.map(s => s.avg_tone),
+        backgroundColor: sources.map(s => toneColorRgba(s.avg_tone, 0.7)),
+        borderColor: sources.map(s => toneColorRgba(s.avg_tone, 1)),
+        borderWidth: 1,
+        borderRadius: 3,
+        barPercentage: 0.7,
+      }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      indexAxis: 'y',
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: ctx => {
+              const s = sources[ctx.dataIndex];
+              return [`Avg tone: ${s.avg_tone > 0 ? '+' : ''}${s.avg_tone.toFixed(2)}`, `${s.article_count} articles`];
+            },
+          },
+          backgroundColor: 'rgba(12,12,16,0.95)',
+          bodyColor: '#b0b0be',
+          borderColor: 'rgba(255,255,255,0.08)',
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 8,
+        },
+      },
+      scales: {
+        x: {
+          title: { display: true, text: 'Average Tone', color: '#6e6e82', font: { size: 11 } },
+          grid: { color: 'rgba(34,34,48,0.4)' },
+        },
+        y: {
+          grid: { display: false },
+          ticks: { font: { size: 11 } },
+        },
+      },
+    },
+  });
+}
+
+function renderDetailSources(d) {
+  const html = d.sources.map(s => {
+    const tCol = toneColor(s.avg_tone);
+    const cls = s.avg_tone >= 0 ? 'pos' : 'neg';
+
+    const articlesHtml = s.articles.slice(0, 8).map(a => {
+      const tCls = (a.tone != null && a.tone >= 0) ? 'pos' : 'neg';
+      return `<div class="source-article">
+        <span class="source-article-title"><a href="${esc(a.url)}" target="_blank" rel="noopener noreferrer">${esc(a.title || '(no title)')}</a></span>
+        <span class="source-article-tone ${tCls}">${a.tone != null ? (a.tone > 0 ? '+' : '') + a.tone.toFixed(1) : '--'}</span>
+      </div>`;
+    }).join('');
+
+    return `<div class="source-group">
+      <div class="source-group-header" onclick="this.parentElement.querySelector('.source-articles').classList.toggle('collapsed')">
+        <span class="source-group-name">${esc(s.source)}</span>
+        <div class="source-group-meta">
+          <span class="source-group-tone" style="color:${tCol}">${s.avg_tone > 0 ? '+' : ''}${s.avg_tone.toFixed(2)}</span>
+          <span class="source-group-count">${s.article_count} articles</span>
+        </div>
+      </div>
+      <div class="source-articles">${articlesHtml}</div>
+    </div>`;
+  }).join('');
+
+  $('#detailSources').innerHTML = html;
+}
+
+// ── Modal controls ───────────────────────────────────────
+
+function closeDetail() {
+  $('#overlay').classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+$('#detailClose').addEventListener('click', closeDetail);
+$('#overlay').addEventListener('click', e => { if (e.target === e.currentTarget) closeDetail(); });
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDetail(); });
+
+// ── Init ─────────────────────────────────────────────────
+
+loadData();
+</script>
+</body>
+</html>

--- a/src/gdelt_event_pipeline/api/static/propagation.html
+++ b/src/gdelt_event_pipeline/api/static/propagation.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" content="#0d1127">
+<title>Story Propagation — Pulse</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#0d1127;
+  --bg2:#131838;
+  --card:rgba(20,26,56,.82);
+  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
+  --text:#e8ecf8;
+  --text2:rgba(232,236,248,.55);
+  --text3:rgba(232,236,248,.3);
+  --accent:#2ee8a5;
+  --accent-soft:rgba(46,232,165,.1);
+  --positive:#2ee8a5;--negative:#ff6b6b;
+  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
+  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
+  --society:#ff9f43;--general:#8899bb;
+  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
+  --mono:'JetBrains Mono',monospace;
+  --r:16px;
+}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100dvh;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none}
+
+/* ── TOP BAR ──────────────────── */
+.bar{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 28px;background:rgba(13,17,39,.85);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.04)}
+.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em;cursor:pointer}
+.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
+@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
+.bar-right{display:flex;align-items:center;gap:12px}
+.bar-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text2);padding:7px 16px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.08);background:none;transition:all .2s}
+.bar-btn:hover{color:var(--text);border-color:rgba(255,255,255,.15);background:rgba(255,255,255,.03)}
+
+/* ── LAYOUT ──────────────────── */
+.hero{text-align:center;padding:48px 28px 32px}
+.hero h1{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1.1;margin-bottom:10px}
+.hero h1 span{color:var(--accent)}
+.hero p{font-size:14px;color:var(--text2);max-width:540px;margin:0 auto;line-height:1.6}
+
+.two-col{display:grid;grid-template-columns:340px 1fr;gap:0;min-height:calc(100dvh - 180px)}
+@media(max-width:900px){.two-col{grid-template-columns:1fr;min-height:auto}}
+
+/* ── STORY LIST (left) ───────── */
+.story-list{border-right:1px solid rgba(255,255,255,.04);overflow-y:auto;max-height:calc(100dvh - 180px);padding:16px}
+@media(max-width:900px){.story-list{max-height:300px;border-right:none;border-bottom:1px solid rgba(255,255,255,.04)}}
+.story-list h3{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);padding:0 8px 12px}
+.story-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:14px 16px;margin-bottom:8px;cursor:pointer;transition:all .2s;box-shadow:var(--card-sh)}
+.story-card:hover{background:rgba(30,38,72,.85);border-color:rgba(255,255,255,.09)}
+.story-card.active{border-color:var(--accent);background:rgba(46,232,165,.06)}
+.story-title{font-size:13px;font-weight:600;line-height:1.35;margin-bottom:8px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.story-meta{display:flex;gap:10px;font-size:10px;color:var(--text3);font-family:var(--mono)}
+.story-meta .pill{background:rgba(46,232,165,.1);color:var(--accent);padding:2px 8px;border-radius:100px;font-weight:600}
+
+/* ── DETAIL PANEL (right) ────── */
+.detail{padding:24px;overflow-y:auto;max-height:calc(100dvh - 180px)}
+@media(max-width:900px){.detail{max-height:none}}
+.detail-empty{display:flex;align-items:center;justify-content:center;height:300px;color:var(--text3);font-size:14px}
+.detail-head{margin-bottom:24px}
+.detail-head h2{font-size:20px;font-weight:700;letter-spacing:-.02em;line-height:1.3;margin-bottom:8px}
+.detail-stats{display:flex;gap:16px;flex-wrap:wrap}
+.d-stat{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);border-radius:12px;padding:12px 18px;text-align:center}
+.d-stat-val{font-size:22px;font-weight:700;font-family:var(--mono)}
+.d-stat-lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:2px}
+
+/* ── HISTOGRAM ───────────────── */
+.chart-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:20px;margin-bottom:20px;box-shadow:var(--card-sh)}
+.chart-card h4{font-size:13px;font-weight:700;margin-bottom:4px}
+.chart-card .chart-sub{font-size:10px;color:var(--text3);margin-bottom:14px}
+.chart-wrap{position:relative;height:200px}
+
+/* ── TIMELINE ────────────────── */
+.timeline{position:relative;padding-left:24px;margin-top:24px}
+.timeline::before{content:'';position:absolute;left:7px;top:0;bottom:0;width:2px;background:linear-gradient(180deg,var(--accent),rgba(46,232,165,.1))}
+.tl-item{position:relative;padding-bottom:20px}
+.tl-dot{position:absolute;left:-21px;top:4px;width:12px;height:12px;border-radius:50%;border:2px solid var(--accent);background:var(--bg)}
+.tl-item.first .tl-dot{background:var(--accent);box-shadow:0 0 8px rgba(46,232,165,.4)}
+.tl-time{font-size:10px;font-family:var(--mono);color:var(--text3);margin-bottom:4px}
+.tl-source{font-size:11px;font-weight:700;color:var(--accent);margin-bottom:2px}
+.tl-title{font-size:13px;font-weight:500;line-height:1.4;color:var(--text)}
+.tl-title a{color:var(--text);transition:color .15s}
+.tl-title a:hover{color:var(--accent)}
+.tl-tone{display:inline-block;font-size:10px;font-weight:700;font-family:var(--mono);padding:1px 7px;border-radius:100px;margin-top:4px}
+
+/* ── SOURCE SPREAD ───────────── */
+.source-spread{margin-top:20px}
+.source-spread h4{font-size:13px;font-weight:700;margin-bottom:14px}
+.spread-bar{display:flex;align-items:center;gap:10px;margin-bottom:8px}
+.spread-name{font-size:12px;font-weight:600;width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.spread-track{flex:1;height:8px;background:rgba(255,255,255,.04);border-radius:4px;position:relative;overflow:hidden}
+.spread-fill{height:100%;border-radius:4px;transition:width .4s ease}
+.spread-count{font-size:11px;font-family:var(--mono);color:var(--text3);width:40px;text-align:right}
+
+/* ── LOADING ─────────────────── */
+.loading{display:flex;align-items:center;justify-content:center;padding:60px;color:var(--text3);gap:10px;font-size:13px}
+.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.08);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+</style>
+</head>
+<body>
+
+<!-- TOP BAR -->
+<header class="bar">
+  <div class="brand" onclick="location.href='/'"><i></i> Pulse</div>
+  <div class="bar-right">
+    <button class="bar-btn" onclick="location.href='/globe'">Globe</button>
+    <button class="bar-btn" onclick="location.href='/'">Home</button>
+  </div>
+</header>
+
+<!-- HERO -->
+<section class="hero">
+  <h1>Story <span>Propagation</span></h1>
+  <p>Track how breaking news spreads across media outlets over time. See which sources break stories first and how coverage cascades.</p>
+</section>
+
+<!-- MAIN LAYOUT -->
+<div class="two-col">
+  <!-- LEFT: story list -->
+  <div class="story-list" id="storyList">
+    <h3>Top Multi-Source Stories</h3>
+    <div class="loading">Loading<span class="spinner"></span></div>
+  </div>
+
+  <!-- RIGHT: detail panel -->
+  <div class="detail" id="detail">
+    <div class="detail-empty">Select a story to see its propagation timeline</div>
+  </div>
+</div>
+
+<script>
+let stories = [];
+let activeStory = null;
+let histoChart = null;
+
+// ── INIT ─────────────────────────────────────────────────────────────
+async function init() {
+  try {
+    const res = await fetch('/api/propagation/stories?limit=30&min_sources=3');
+    stories = await res.json();
+    renderStoryList();
+    if (stories.length > 0) selectStory(stories[0].id);
+  } catch (e) {
+    document.getElementById('storyList').innerHTML = '<div style="padding:40px;text-align:center;color:var(--text3)">Failed to load stories</div>';
+  }
+}
+
+// ── STORY LIST ───────────────────────────────────────────────────────
+function renderStoryList() {
+  const el = document.getElementById('storyList');
+  el.innerHTML = '<h3>Top Multi-Source Stories</h3>' + stories.map(s => {
+    const span = s.span_hours > 24 ? `${Math.round(s.span_hours / 24)}d` : `${Math.round(s.span_hours)}h`;
+    return `<div class="story-card" data-id="${s.id}" onclick="selectStory('${s.id}')">
+      <div class="story-title">${esc(s.title)}</div>
+      <div class="story-meta">
+        <span class="pill">${s.source_count} sources</span>
+        <span>${s.article_count} articles</span>
+        <span>${span} span</span>
+      </div>
+    </div>`;
+  }).join('');
+}
+
+// ── SELECT & LOAD DETAIL ─────────────────────────────────────────────
+async function selectStory(id) {
+  activeStory = id;
+  document.querySelectorAll('.story-card').forEach(c => c.classList.toggle('active', c.dataset.id === id));
+  const detail = document.getElementById('detail');
+  detail.innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+
+  try {
+    const res = await fetch(`/api/propagation/${id}`);
+    const d = await res.json();
+    renderDetail(d);
+  } catch (e) {
+    detail.innerHTML = '<div class="detail-empty">Failed to load propagation data</div>';
+  }
+}
+
+// ── RENDER DETAIL ────────────────────────────────────────────────────
+function renderDetail(d) {
+  const detail = document.getElementById('detail');
+  const spanH = d.first_article_at && d.last_article_at
+    ? Math.round((new Date(d.last_article_at) - new Date(d.first_article_at)) / 3600000)
+    : 0;
+
+  // Source colors
+  const srcColors = {};
+  const palette = ['#2ee8a5','#7b8aff','#ff6b6b','#ffc844','#22d4e6','#a78bfa','#ff9f43','#60a5fa','#e879f9','#34d399','#f97316','#818cf8'];
+  d.sources.forEach((s, i) => { srcColors[s.domain] = palette[i % palette.length]; });
+
+  const maxArticles = Math.max(...d.sources.map(s => s.article_count));
+
+  let html = `
+    <div class="detail-head">
+      <h2>${esc(d.title)}</h2>
+      <div class="detail-stats">
+        <div class="d-stat"><div class="d-stat-val">${d.article_count}</div><div class="d-stat-lbl">Articles</div></div>
+        <div class="d-stat"><div class="d-stat-val">${d.source_count}</div><div class="d-stat-lbl">Sources</div></div>
+        <div class="d-stat"><div class="d-stat-val">${spanH}h</div><div class="d-stat-lbl">Time Span</div></div>
+      </div>
+    </div>
+
+    <div class="chart-card">
+      <h4>Article Volume Over Time</h4>
+      <div class="chart-sub">Hourly article count since first publication</div>
+      <div class="chart-wrap"><canvas id="histoChart"></canvas></div>
+    </div>
+
+    <div class="source-spread">
+      <h4>Source Cascade — Order of Pickup</h4>
+      ${d.sources.map(s => {
+        const col = srcColors[s.domain];
+        const pct = Math.round(s.article_count / maxArticles * 100);
+        const delay = s.order === 0 ? 'FIRST' :
+          (() => {
+            const firstTs = new Date(d.sources[0].first_timestamp);
+            const thisTs = new Date(s.first_timestamp);
+            const mins = Math.round((thisTs - firstTs) / 60000);
+            return mins < 60 ? `+${mins}m` : `+${Math.round(mins / 60)}h`;
+          })();
+        return `<div class="spread-bar">
+          <span class="spread-name" style="color:${col}">${esc(s.source_name)}</span>
+          <div class="spread-track"><div class="spread-fill" style="width:${pct}%;background:${col}"></div></div>
+          <span class="spread-count">${s.article_count}</span>
+          <span style="font-size:10px;font-family:var(--mono);color:${s.order === 0 ? 'var(--accent)' : 'var(--text3)'};width:50px;text-align:right;font-weight:${s.order === 0 ? '700' : '400'}">${delay}</span>
+        </div>`;
+      }).join('')}
+    </div>
+
+    <div style="margin-top:28px">
+      <h4 style="font-size:13px;font-weight:700;margin-bottom:16px">Propagation Timeline</h4>
+      <div class="timeline">
+        ${d.timeline.map((e, i) => {
+          const col = srcColors[e.domain];
+          const ts = new Date(e.timestamp);
+          const time = ts.toLocaleDateString('en-US', {month:'short',day:'numeric'}) + ' ' +
+                       ts.toLocaleTimeString('en-US', {hour:'2-digit',minute:'2-digit'});
+          const toneCol = e.tone != null ? (e.tone >= 0 ? 'var(--positive)' : 'var(--negative)') : null;
+          return `<div class="tl-item ${e.is_first_from_source ? 'first' : ''}">
+            <div class="tl-dot" style="border-color:${col};${e.is_first_from_source ? `background:${col}` : ''}"></div>
+            <div class="tl-time">${time}</div>
+            <div class="tl-source" style="color:${col}">${esc(e.source_name)} ${e.is_first_from_source ? '<span style="font-size:9px;background:'+col+'22;padding:1px 6px;border-radius:100px">NEW SOURCE</span>' : ''}</div>
+            <div class="tl-title"><a href="${esc(e.url)}" target="_blank">${esc(e.title)}</a></div>
+            ${e.tone != null ? `<span class="tl-tone" style="background:${toneCol}18;color:${toneCol}">${e.tone >= 0 ? '+' : ''}${e.tone}</span>` : ''}
+          </div>`;
+        }).join('')}
+      </div>
+    </div>
+  `;
+
+  detail.innerHTML = html;
+
+  // Render histogram
+  if (d.hourly_histogram.length > 0) {
+    setTimeout(() => renderHistogram(d.hourly_histogram), 50);
+  }
+}
+
+function renderHistogram(data) {
+  const ctx = document.getElementById('histoChart');
+  if (!ctx) return;
+  if (histoChart) histoChart.destroy();
+
+  histoChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: data.map(d => `+${d.hour}h`),
+      datasets: [{
+        data: data.map(d => d.count),
+        backgroundColor: 'rgba(46,232,165,.3)',
+        borderColor: '#2ee8a5',
+        borderWidth: 1.5,
+        borderRadius: 4,
+        hoverBackgroundColor: 'rgba(46,232,165,.5)'
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(13,17,39,.95)',
+          borderColor: 'rgba(255,255,255,.08)',
+          borderWidth: 1,
+          bodyFont: { family: "'JetBrains Mono'", size: 11 },
+          padding: 10,
+          cornerRadius: 8,
+          callbacks: { label: ctx => `${ctx.raw} articles` }
+        }
+      },
+      scales: {
+        x: {
+          grid: { color: 'rgba(255,255,255,.03)' },
+          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 }, maxTicksLimit: 12 }
+        },
+        y: {
+          grid: { color: 'rgba(255,255,255,.03)' },
+          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 }, stepSize: 1 }
+        }
+      }
+    }
+  });
+}
+
+function esc(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+init();
+</script>
+</body>
+</html>

--- a/src/gdelt_event_pipeline/api/static/sources.html
+++ b/src/gdelt_event_pipeline/api/static/sources.html
@@ -1,0 +1,585 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" content="#0d1127">
+<title>Source DNA — Pulse</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#0d1127;
+  --bg2:#131838;
+  --card:rgba(20,26,56,.82);
+  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
+  --text:#e8ecf8;
+  --text2:rgba(232,236,248,.55);
+  --text3:rgba(232,236,248,.3);
+  --accent:#2ee8a5;
+  --accent-soft:rgba(46,232,165,.1);
+  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
+  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
+  --society:#ff9f43;--general:#8899bb;
+  --positive:#2ee8a5;--negative:#ff6b6b;
+  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
+  --mono:'JetBrains Mono',monospace;
+  --r:16px;
+}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100dvh;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none}
+
+/* ── TOP BAR ──────────────────── */
+.bar{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 28px;background:rgba(13,17,39,.85);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.04)}
+.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em;cursor:pointer}
+.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
+@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
+.bar-right{display:flex;align-items:center;gap:12px}
+.bar-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text2);padding:7px 16px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.08);background:none;transition:all .2s}
+.bar-btn:hover{color:var(--text);border-color:rgba(255,255,255,.15);background:rgba(255,255,255,.03)}
+
+/* ── HERO ─────────────────────── */
+.hero{text-align:center;padding:48px 28px 32px}
+.hero h1{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1.1;margin-bottom:10px}
+.hero h1 span{color:var(--accent)}
+.hero p{font-size:14px;color:var(--text2);max-width:520px;margin:0 auto;line-height:1.6}
+
+/* ── CONTROLS ─────────────────── */
+.controls{display:flex;justify-content:center;gap:8px;padding:0 28px 28px;flex-wrap:wrap}
+.ctrl-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text3);padding:7px 18px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.06);background:none;transition:all .25s}
+.ctrl-btn:hover{color:var(--text2);border-color:rgba(255,255,255,.12)}
+.ctrl-btn.on{color:var(--text);background:var(--accent-soft);border-color:var(--accent)}
+
+/* ── OVERVIEW STATS ──────────── */
+.stats-row{display:flex;gap:12px;padding:0 28px 28px;flex-wrap:wrap;justify-content:center}
+.stat-box{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:18px 24px;min-width:140px;text-align:center;box-shadow:var(--card-sh)}
+.stat-val{font-size:26px;font-weight:700;letter-spacing:-.02em;font-family:var(--mono)}
+.stat-lbl{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:4px}
+
+/* ── SCATTER CHART ───────────── */
+.chart-section{padding:0 28px 28px}
+.chart-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:24px;box-shadow:var(--card-sh)}
+.chart-title{font-size:14px;font-weight:700;margin-bottom:4px}
+.chart-sub{font-size:11px;color:var(--text3);margin-bottom:16px}
+.chart-wrap{position:relative;height:360px}
+
+/* ── SOURCE TABLE ────────────── */
+.table-section{padding:0 28px 40px}
+.table-wrap{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);overflow:hidden;box-shadow:var(--card-sh)}
+.table-header{display:flex;align-items:center;justify-content:space-between;padding:18px 20px 14px;border-bottom:1px solid rgba(255,255,255,.04)}
+.table-header h3{font-size:14px;font-weight:700}
+.table-search{font-family:var(--sans);font-size:12px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:100px;padding:7px 16px;color:var(--text);outline:none;width:220px;transition:border-color .2s}
+.table-search:focus{border-color:var(--accent)}
+.table-search::placeholder{color:var(--text3)}
+table{width:100%;border-collapse:collapse}
+thead th{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);text-align:left;padding:10px 16px;border-bottom:1px solid rgba(255,255,255,.04);cursor:pointer;user-select:none;white-space:nowrap;transition:color .2s}
+thead th:hover{color:var(--text2)}
+thead th.sorted{color:var(--accent)}
+thead th .arrow{font-size:8px;margin-left:4px}
+tbody tr{border-bottom:1px solid rgba(255,255,255,.02);transition:background .15s;cursor:pointer}
+tbody tr:hover{background:rgba(46,232,165,.03)}
+tbody td{padding:12px 16px;font-size:13px;white-space:nowrap}
+.src-name{font-weight:600;max-width:200px;overflow:hidden;text-overflow:ellipsis}
+.tone-bar{display:flex;height:6px;border-radius:3px;overflow:hidden;width:100px;background:rgba(255,255,255,.04)}
+.tone-pos{background:var(--positive);height:100%}
+.tone-neg{background:var(--negative);height:100%}
+.theme-tags{display:flex;gap:4px;flex-wrap:nowrap;max-width:200px;overflow:hidden}
+.theme-tag{font-size:9px;font-weight:600;padding:2px 7px;border-radius:100px;white-space:nowrap}
+
+/* ── DETAIL MODAL ────────────── */
+.modal-bg{position:fixed;inset:0;z-index:200;background:rgba(0,0,0,.6);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);opacity:0;pointer-events:none;transition:opacity .3s}
+.modal-bg.on{opacity:1;pointer-events:auto}
+.modal{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(.95);z-index:201;width:min(720px,92vw);max-height:85vh;background:var(--bg2);border:1px solid rgba(255,255,255,.06);border-radius:calc(var(--r) + 4px);overflow:hidden;opacity:0;pointer-events:none;transition:all .35s cubic-bezier(.4,0,.2,1);display:flex;flex-direction:column}
+.modal-bg.on+.modal,.modal.on{opacity:1;pointer-events:auto;transform:translate(-50%,-50%) scale(1)}
+.modal-head{display:flex;align-items:center;justify-content:space-between;padding:20px 24px;border-bottom:1px solid rgba(255,255,255,.04)}
+.modal-head h2{font-size:18px;font-weight:700;letter-spacing:-.02em}
+.modal-head .domain-tag{font-size:11px;font-weight:500;color:var(--text2);font-family:var(--mono);margin-left:12px}
+.modal-close{width:32px;height:32px;border-radius:50%;border:none;background:rgba(255,255,255,.06);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;color:var(--text2);transition:background .2s}
+.modal-close:hover{background:rgba(255,255,255,.12)}
+.modal-body{padding:24px;overflow-y:auto;flex:1}
+.modal-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:24px}
+.m-stat{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);border-radius:12px;padding:14px;text-align:center}
+.m-stat-val{font-size:20px;font-weight:700;font-family:var(--mono)}
+.m-stat-lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:2px}
+.modal-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:24px}
+.modal-chart-card{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:12px;padding:16px}
+.modal-chart-card h4{font-size:12px;font-weight:700;margin-bottom:12px}
+.modal-chart-wrap{position:relative;height:200px}
+.recent-list{display:flex;flex-direction:column;gap:8px}
+.recent-item{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:12px;padding:12px 16px;transition:background .15s}
+.recent-item:hover{background:rgba(255,255,255,.04)}
+.recent-title{font-size:13px;font-weight:600;margin-bottom:4px;line-height:1.4}
+.recent-meta{font-size:10px;color:var(--text3);display:flex;gap:12px;align-items:center}
+.tone-chip{font-size:10px;font-weight:700;font-family:var(--mono);padding:2px 8px;border-radius:100px}
+
+/* ── LOADING ─────────────────── */
+.loading{display:flex;align-items:center;justify-content:center;padding:60px;color:var(--text3);gap:10px;font-size:13px}
+.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.08);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* ── RESPONSIVE ──────────────── */
+@media(max-width:768px){
+  .hero h1{font-size:26px}
+  .stats-row{gap:8px}
+  .stat-box{min-width:100px;padding:14px 16px}
+  .stat-val{font-size:20px}
+  .chart-wrap{height:260px}
+  .modal-stats{grid-template-columns:repeat(2,1fr)}
+  .modal-grid{grid-template-columns:1fr}
+  .table-search{width:160px}
+  .theme-tags{display:none}
+}
+</style>
+</head>
+<body>
+
+<!-- TOP BAR -->
+<header class="bar">
+  <div class="brand" onclick="location.href='/'"><i></i> Pulse</div>
+  <div class="bar-right">
+    <button class="bar-btn" onclick="location.href='/globe'">Globe</button>
+    <button class="bar-btn" onclick="location.href='/'">Home</button>
+  </div>
+</header>
+
+<!-- HERO -->
+<section class="hero">
+  <h1>Source <span>DNA</span></h1>
+  <p>Fingerprint every news source by what they cover, how they cover it, and where they focus. Compare editorial DNA across thousands of outlets.</p>
+</section>
+
+<!-- OVERVIEW STATS -->
+<div class="stats-row" id="statsRow">
+  <div class="stat-box"><div class="stat-val" id="statSources">--</div><div class="stat-lbl">Sources</div></div>
+  <div class="stat-box"><div class="stat-val" id="statArticles">--</div><div class="stat-lbl">Articles</div></div>
+  <div class="stat-box"><div class="stat-val" id="statAvgTone">--</div><div class="stat-lbl">Avg Tone</div></div>
+  <div class="stat-box"><div class="stat-val" id="statMostPositive">--</div><div class="stat-lbl">Most Positive</div></div>
+</div>
+
+<!-- SORT CONTROLS -->
+<div class="controls">
+  <button class="ctrl-btn on" data-sort="articles" onclick="setSort('articles')">Most Articles</button>
+  <button class="ctrl-btn" data-sort="tone_positive" onclick="setSort('tone_positive')">Most Positive</button>
+  <button class="ctrl-btn" data-sort="tone_negative" onclick="setSort('tone_negative')">Most Negative</button>
+</div>
+
+<!-- SCATTER CHART -->
+<section class="chart-section">
+  <div class="chart-card">
+    <div class="chart-title">Source Landscape</div>
+    <div class="chart-sub">Bubble size = article count. X = avg tone. Y = polarity (spread between positive &amp; negative).</div>
+    <div class="chart-wrap"><canvas id="scatterChart"></canvas></div>
+  </div>
+</section>
+
+<!-- SOURCE TABLE -->
+<section class="table-section">
+  <div class="table-wrap">
+    <div class="table-header">
+      <h3>All Sources</h3>
+      <input type="text" class="table-search" placeholder="Filter sources..." oninput="filterTable(this.value)">
+    </div>
+    <div style="overflow-x:auto">
+      <table>
+        <thead>
+          <tr>
+            <th class="sorted" data-col="article_count" onclick="sortTable('article_count')">Articles <span class="arrow">▼</span></th>
+            <th data-col="source_name" onclick="sortTable('source_name')">Source</th>
+            <th data-col="avg_tone" onclick="sortTable('avg_tone')">Tone</th>
+            <th data-col="avg_polarity" onclick="sortTable('avg_polarity')">Polarity</th>
+            <th>Tone Balance</th>
+            <th>Top Themes</th>
+          </tr>
+        </thead>
+        <tbody id="srcBody">
+          <tr><td colspan="6"><div class="loading">Loading<span class="spinner"></span></div></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- DETAIL MODAL -->
+<div class="modal-bg" id="modalBg" onclick="closeModal()"></div>
+<div class="modal" id="modal">
+  <div class="modal-head">
+    <div style="display:flex;align-items:center"><h2 id="modalTitle"></h2><span class="domain-tag" id="modalDomain"></span></div>
+    <button class="modal-close" onclick="closeModal()">&#10005;</button>
+  </div>
+  <div class="modal-body" id="modalBody">
+    <div class="loading">Loading<span class="spinner"></span></div>
+  </div>
+</div>
+
+<script>
+const CAT_COLORS = {conflict:'#ff6b6b',economy:'#ffc844',politics:'#7b8aff',health:'#2ee8a5',environment:'#22d4e6',technology:'#a78bfa',society:'#ff9f43',general:'#8899bb'};
+
+let allSources = [];
+let currentSort = 'articles';
+let scatterChart = null;
+
+// ── INIT ─────────────────────────────────────────────────────────────
+async function init() {
+  try {
+    const res = await fetch('/api/sources/fingerprints?limit=100&min_articles=5');
+    allSources = await res.json();
+    renderStats();
+    renderScatter();
+    renderTable(allSources);
+  } catch (e) {
+    document.getElementById('srcBody').innerHTML = '<tr><td colspan="6" style="padding:40px;text-align:center;color:var(--text3)">Failed to load sources</td></tr>';
+  }
+}
+
+// ── STATS ────────────────────────────────────────────────────────────
+function renderStats() {
+  const s = allSources;
+  document.getElementById('statSources').textContent = s.length.toLocaleString();
+  const totalArticles = s.reduce((a,b) => a + b.article_count, 0);
+  document.getElementById('statArticles').textContent = totalArticles.toLocaleString();
+  const avgTone = s.reduce((a,b) => a + b.avg_tone * b.article_count, 0) / totalArticles;
+  document.getElementById('statAvgTone').textContent = avgTone.toFixed(2);
+  const mostPos = s.reduce((a,b) => b.avg_tone > a.avg_tone ? b : a);
+  document.getElementById('statMostPositive').textContent = truncate(mostPos.source_name, 18);
+}
+
+// ── SCATTER ──────────────────────────────────────────────────────────
+function renderScatter() {
+  const ctx = document.getElementById('scatterChart').getContext('2d');
+  const data = allSources.map(s => ({
+    x: s.avg_tone,
+    y: s.avg_polarity,
+    r: Math.max(4, Math.min(30, Math.sqrt(s.article_count) * 1.2)),
+    label: s.source_name,
+    domain: s.domain,
+    articles: s.article_count,
+    category: s.top_themes.length > 0 ? s.top_themes[0].category : 'general'
+  }));
+
+  if (scatterChart) scatterChart.destroy();
+  scatterChart = new Chart(ctx, {
+    type: 'bubble',
+    data: {
+      datasets: [{
+        data: data,
+        backgroundColor: data.map(d => {
+          const c = CAT_COLORS[d.category] || CAT_COLORS.general;
+          return c + '66';
+        }),
+        borderColor: data.map(d => {
+          const c = CAT_COLORS[d.category] || CAT_COLORS.general;
+          return c + 'cc';
+        }),
+        borderWidth: 1.5,
+        hoverBorderWidth: 2.5
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(13,17,39,.95)',
+          borderColor: 'rgba(255,255,255,.08)',
+          borderWidth: 1,
+          titleFont: { family: "'DM Sans'", weight: '700', size: 13 },
+          bodyFont: { family: "'DM Sans'", size: 11 },
+          padding: 12,
+          cornerRadius: 10,
+          callbacks: {
+            title: ctx => ctx[0].raw.label,
+            label: ctx => [
+              `Tone: ${ctx.raw.x.toFixed(2)}`,
+              `Polarity: ${ctx.raw.y.toFixed(2)}`,
+              `Articles: ${ctx.raw.articles.toLocaleString()}`
+            ]
+          }
+        }
+      },
+      scales: {
+        x: {
+          title: { display: true, text: 'Average Tone', color: 'rgba(232,236,248,.3)', font: { family: "'DM Sans'", size: 11, weight: '600' } },
+          grid: { color: 'rgba(255,255,255,.03)' },
+          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 10 } }
+        },
+        y: {
+          title: { display: true, text: 'Polarity', color: 'rgba(232,236,248,.3)', font: { family: "'DM Sans'", size: 11, weight: '600' } },
+          grid: { color: 'rgba(255,255,255,.03)' },
+          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 10 } }
+        }
+      },
+      onClick: (evt, els) => {
+        if (els.length > 0) {
+          const d = data[els[0].index];
+          openModal(d.domain);
+        }
+      }
+    }
+  });
+}
+
+// ── TABLE ────────────────────────────────────────────────────────────
+function renderTable(sources) {
+  const tbody = document.getElementById('srcBody');
+  if (!sources.length) {
+    tbody.innerHTML = '<tr><td colspan="6" style="padding:40px;text-align:center;color:var(--text3)">No sources found</td></tr>';
+    return;
+  }
+  tbody.innerHTML = sources.map(s => {
+    const posW = s.avg_positive ? Math.round(s.avg_positive / (s.avg_positive + s.avg_negative) * 100) : 50;
+    const themes = (s.top_themes || []).slice(0, 3).map(t => {
+      const col = CAT_COLORS[t.category] || CAT_COLORS.general;
+      return `<span class="theme-tag" style="background:${col}22;color:${col}">${humanTheme(t.theme)}</span>`;
+    }).join('');
+    return `<tr onclick="openModal('${s.domain}')">
+      <td style="font-family:var(--mono);font-weight:600">${s.article_count.toLocaleString()}</td>
+      <td class="src-name">${esc(s.source_name)}</td>
+      <td style="font-family:var(--mono);color:${s.avg_tone >= 0 ? 'var(--positive)' : 'var(--negative)'}">${s.avg_tone >= 0 ? '+' : ''}${s.avg_tone.toFixed(2)}</td>
+      <td style="font-family:var(--mono)">${s.avg_polarity.toFixed(2)}</td>
+      <td><div class="tone-bar"><div class="tone-pos" style="width:${posW}%"></div><div class="tone-neg" style="width:${100 - posW}%"></div></div></td>
+      <td><div class="theme-tags">${themes}</div></td>
+    </tr>`;
+  }).join('');
+}
+
+let tableSortCol = 'article_count';
+let tableSortAsc = false;
+
+function sortTable(col) {
+  if (tableSortCol === col) {
+    tableSortAsc = !tableSortAsc;
+  } else {
+    tableSortCol = col;
+    tableSortAsc = col === 'source_name';
+  }
+  document.querySelectorAll('thead th').forEach(th => {
+    th.classList.toggle('sorted', th.dataset.col === col);
+    const arrow = th.querySelector('.arrow');
+    if (arrow) arrow.textContent = th.dataset.col === col ? (tableSortAsc ? '▲' : '▼') : '';
+  });
+  const sorted = [...allSources].sort((a, b) => {
+    let va = a[col], vb = b[col];
+    if (typeof va === 'string') return tableSortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+    return tableSortAsc ? va - vb : vb - va;
+  });
+  renderTable(sorted);
+}
+
+function filterTable(q) {
+  q = q.toLowerCase();
+  const filtered = allSources.filter(s => s.source_name.toLowerCase().includes(q) || s.domain.toLowerCase().includes(q));
+  renderTable(filtered);
+}
+
+// ── SORT CONTROLS ────────────────────────────────────────────────────
+function setSort(sort) {
+  currentSort = sort;
+  document.querySelectorAll('.ctrl-btn').forEach(b => b.classList.toggle('on', b.dataset.sort === sort));
+  fetch(`/api/sources/fingerprints?limit=100&min_articles=5&sort=${sort}`)
+    .then(r => r.json())
+    .then(data => {
+      allSources = data;
+      renderStats();
+      renderScatter();
+      tableSortCol = sort === 'articles' ? 'article_count' : 'avg_tone';
+      tableSortAsc = sort === 'tone_negative';
+      renderTable(allSources);
+    });
+}
+
+// ── MODAL ────────────────────────────────────────────────────────────
+let toneTimelineChart = null;
+let categoryChart = null;
+
+async function openModal(domain) {
+  document.getElementById('modalBg').classList.add('on');
+  document.getElementById('modal').classList.add('on');
+  document.getElementById('modalTitle').textContent = 'Loading...';
+  document.getElementById('modalDomain').textContent = '';
+  document.getElementById('modalBody').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+
+  try {
+    const res = await fetch(`/api/sources/${encodeURIComponent(domain)}/detail`);
+    const d = await res.json();
+    renderModal(d);
+  } catch (e) {
+    document.getElementById('modalBody').innerHTML = '<p style="color:var(--text3);text-align:center;padding:40px">Failed to load source details</p>';
+  }
+}
+
+function renderModal(d) {
+  document.getElementById('modalTitle').textContent = d.source_name;
+  document.getElementById('modalDomain').textContent = d.domain;
+
+  const toneColor = d.avg_tone >= 0 ? 'var(--positive)' : 'var(--negative)';
+
+  let html = `
+    <div class="modal-stats">
+      <div class="m-stat"><div class="m-stat-val">${d.article_count.toLocaleString()}</div><div class="m-stat-lbl">Articles</div></div>
+      <div class="m-stat"><div class="m-stat-val" style="color:${toneColor}">${d.avg_tone >= 0 ? '+' : ''}${d.avg_tone.toFixed(2)}</div><div class="m-stat-lbl">Avg Tone</div></div>
+      <div class="m-stat"><div class="m-stat-val">${d.avg_polarity.toFixed(2)}</div><div class="m-stat-lbl">Polarity</div></div>
+      <div class="m-stat"><div class="m-stat-val">${d.countries.length}</div><div class="m-stat-lbl">Countries</div></div>
+    </div>
+
+    <div class="modal-grid">
+      <div class="modal-chart-card">
+        <h4>Tone Over Time</h4>
+        <div class="modal-chart-wrap"><canvas id="toneTimeline"></canvas></div>
+      </div>
+      <div class="modal-chart-card">
+        <h4>Coverage Categories</h4>
+        <div class="modal-chart-wrap"><canvas id="categoryChart"></canvas></div>
+      </div>
+    </div>
+
+    <div class="modal-chart-card" style="margin-bottom:24px">
+      <h4>Top Themes</h4>
+      <div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px">
+        ${d.themes.slice(0, 15).map(t => {
+          const col = CAT_COLORS[t.category] || CAT_COLORS.general;
+          return `<span class="theme-tag" style="background:${col}22;color:${col};padding:4px 10px;font-size:11px">${humanTheme(t.theme)} <span style="opacity:.5;margin-left:2px">${t.count}</span></span>`;
+        }).join('')}
+      </div>
+    </div>
+
+    <div class="modal-chart-card">
+      <h4>Recent Articles</h4>
+      <div class="recent-list" style="margin-top:12px">
+        ${d.recent_articles.map(a => {
+          const tone = a.tone_score;
+          const col = tone != null ? (tone >= 0 ? 'var(--positive)' : 'var(--negative)') : 'var(--text3)';
+          const ts = a.gdelt_timestamp ? new Date(a.gdelt_timestamp).toLocaleDateString('en-US', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : '';
+          return `<a href="${esc(a.url)}" target="_blank" class="recent-item" style="text-decoration:none;color:var(--text)">
+            <div class="recent-title">${esc(a.title)}</div>
+            <div class="recent-meta">
+              <span>${ts}</span>
+              ${tone != null ? `<span class="tone-chip" style="background:${col}18;color:${col}">${tone >= 0 ? '+' : ''}${tone.toFixed(1)}</span>` : ''}
+            </div>
+          </a>`;
+        }).join('')}
+      </div>
+    </div>
+  `;
+
+  document.getElementById('modalBody').innerHTML = html;
+
+  // Render tone timeline chart
+  if (d.tone_timeline.length > 1) {
+    setTimeout(() => renderToneTimeline(d.tone_timeline), 50);
+  }
+  if (d.categories.length > 0) {
+    setTimeout(() => renderCategoryChart(d.categories), 50);
+  }
+}
+
+function renderToneTimeline(timeline) {
+  const ctx = document.getElementById('toneTimeline');
+  if (!ctx) return;
+  if (toneTimelineChart) toneTimelineChart.destroy();
+
+  toneTimelineChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: timeline.map(t => {
+        const d = new Date(t.day);
+        return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      }),
+      datasets: [{
+        data: timeline.map(t => t.avg_tone),
+        borderColor: '#2ee8a5',
+        backgroundColor: 'rgba(46,232,165,.1)',
+        fill: true,
+        tension: 0.4,
+        pointRadius: 2,
+        pointHoverRadius: 5,
+        borderWidth: 2
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false }, tooltip: {
+        backgroundColor: 'rgba(13,17,39,.95)',
+        borderColor: 'rgba(255,255,255,.08)',
+        borderWidth: 1,
+        titleFont: { family: "'DM Sans'", size: 11 },
+        bodyFont: { family: "'JetBrains Mono'", size: 11 },
+        padding: 10,
+        cornerRadius: 8,
+        callbacks: {
+          label: ctx => `Tone: ${ctx.raw.toFixed(3)}`
+        }
+      }},
+      scales: {
+        x: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { size: 9 }, maxTicksLimit: 8 } },
+        y: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 } } }
+      }
+    }
+  });
+}
+
+function renderCategoryChart(categories) {
+  const ctx = document.getElementById('categoryChart');
+  if (!ctx) return;
+  if (categoryChart) categoryChart.destroy();
+
+  categoryChart = new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: categories.map(c => c.category.charAt(0).toUpperCase() + c.category.slice(1)),
+      datasets: [{
+        data: categories.map(c => c.pct),
+        backgroundColor: categories.map(c => (CAT_COLORS[c.category] || CAT_COLORS.general) + '88'),
+        borderColor: categories.map(c => (CAT_COLORS[c.category] || CAT_COLORS.general)),
+        borderWidth: 1.5
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      cutout: '55%',
+      plugins: {
+        legend: {
+          position: 'right',
+          labels: { color: 'rgba(232,236,248,.55)', font: { family: "'DM Sans'", size: 10, weight: '600' }, padding: 8, boxWidth: 10, boxHeight: 10, borderRadius: 3 }
+        },
+        tooltip: {
+          backgroundColor: 'rgba(13,17,39,.95)',
+          bodyFont: { family: "'DM Sans'", size: 11 },
+          padding: 10,
+          cornerRadius: 8,
+          callbacks: { label: ctx => ` ${ctx.label}: ${ctx.raw}%` }
+        }
+      }
+    }
+  });
+}
+
+function closeModal() {
+  document.getElementById('modalBg').classList.remove('on');
+  document.getElementById('modal').classList.remove('on');
+  if (toneTimelineChart) { toneTimelineChart.destroy(); toneTimelineChart = null; }
+  if (categoryChart) { categoryChart.destroy(); categoryChart = null; }
+}
+
+// ── HELPERS ──────────────────────────────────────────────────────────
+function humanTheme(t) {
+  return t.replace(/^(WB_\d+_|USPEC_|ENV_|EPU_|TAX_|CRISISLEX_|GENERAL_|SOC_)/, '')
+          .replace(/_/g, ' ')
+          .toLowerCase()
+          .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function truncate(s, n) { return s.length > n ? s.slice(0, n) + '...' : s; }
+function esc(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+// Close modal on Escape
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+
+init();
+</script>
+</body>
+</html>

--- a/src/gdelt_event_pipeline/api/static/velocity.html
+++ b/src/gdelt_event_pipeline/api/static/velocity.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" content="#0d1127">
+<title>Topic Velocity — Pulse</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#0d1127;
+  --bg2:#131838;
+  --card:rgba(20,26,56,.82);
+  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
+  --text:#e8ecf8;
+  --text2:rgba(232,236,248,.55);
+  --text3:rgba(232,236,248,.3);
+  --accent:#2ee8a5;
+  --accent-soft:rgba(46,232,165,.1);
+  --rising:#2ee8a5;--declining:#ff6b6b;
+  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
+  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
+  --society:#ff9f43;--general:#8899bb;
+  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
+  --mono:'JetBrains Mono',monospace;
+  --r:16px;
+}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100dvh;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none}
+
+.bar{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 28px;background:rgba(13,17,39,.85);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.04)}
+.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em;cursor:pointer}
+.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
+@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
+.bar-right{display:flex;align-items:center;gap:12px}
+.bar-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text2);padding:7px 16px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.08);background:none;transition:all .2s}
+.bar-btn:hover{color:var(--text);border-color:rgba(255,255,255,.15);background:rgba(255,255,255,.03)}
+
+.hero{text-align:center;padding:48px 28px 24px}
+.hero h1{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1.1;margin-bottom:10px}
+.hero h1 span{color:var(--accent)}
+.hero p{font-size:14px;color:var(--text2);max-width:520px;margin:0 auto;line-height:1.6}
+
+.controls{display:flex;justify-content:center;gap:8px;padding:0 28px 28px;flex-wrap:wrap}
+.ctrl-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text3);padding:7px 18px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.06);background:none;transition:all .25s}
+.ctrl-btn:hover{color:var(--text2);border-color:rgba(255,255,255,.12)}
+.ctrl-btn.on{color:var(--text);background:var(--accent-soft);border-color:var(--accent)}
+
+.content{max-width:1100px;margin:0 auto;padding:0 28px 40px}
+.two-col{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-bottom:24px}
+@media(max-width:768px){.two-col{grid-template-columns:1fr}}
+
+.panel{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);overflow:hidden;box-shadow:var(--card-sh)}
+.panel-head{display:flex;align-items:center;gap:8px;padding:16px 20px 12px;border-bottom:1px solid rgba(255,255,255,.04)}
+.panel-head h3{font-size:14px;font-weight:700}
+.panel-head .badge{font-size:10px;font-weight:700;padding:3px 10px;border-radius:100px;font-family:var(--mono)}
+.badge-rising{background:rgba(46,232,165,.12);color:var(--rising)}
+.badge-declining{background:rgba(255,107,107,.12);color:var(--declining)}
+
+.topic-row{display:flex;align-items:center;gap:12px;padding:10px 20px;border-bottom:1px solid rgba(255,255,255,.02);cursor:pointer;transition:background .15s}
+.topic-row:hover{background:rgba(46,232,165,.03)}
+.topic-row.active{background:rgba(46,232,165,.06);border-left:3px solid var(--accent)}
+
+.t-rank{font-size:11px;font-family:var(--mono);color:var(--text3);width:24px;text-align:center;flex-shrink:0}
+.t-info{flex:1;min-width:0}
+.t-name{font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.t-cat{font-size:9px;font-weight:600;padding:2px 7px;border-radius:100px;margin-top:2px;display:inline-block}
+.t-stats{display:flex;gap:8px;align-items:center;flex-shrink:0}
+.t-count{font-size:11px;font-family:var(--mono);color:var(--text3)}
+.t-vel{font-size:12px;font-weight:700;font-family:var(--mono);min-width:60px;text-align:right}
+.t-vel.up{color:var(--rising)}
+.t-vel.down{color:var(--declining)}
+.t-bar-wrap{width:60px;height:6px;background:rgba(255,255,255,.04);border-radius:3px;overflow:hidden}
+.t-bar{height:100%;border-radius:3px}
+
+/* ── DETAIL PANEL ────────────── */
+.detail-section{margin-top:24px}
+.detail-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:24px;box-shadow:var(--card-sh)}
+.detail-card h3{font-size:16px;font-weight:700;margin-bottom:4px}
+.detail-card .detail-sub{font-size:11px;color:var(--text3);margin-bottom:20px}
+.chart-wrap{position:relative;height:260px;margin-bottom:20px}
+
+.detail-stats{display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap}
+.d-stat{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);border-radius:12px;padding:14px 18px;text-align:center;flex:1;min-width:100px}
+.d-stat-val{font-size:22px;font-weight:700;font-family:var(--mono)}
+.d-stat-lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:2px}
+
+.articles-list{display:flex;flex-direction:column;gap:8px}
+.articles-list h4{font-size:13px;font-weight:700;margin-bottom:8px}
+.art-item{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:12px;padding:12px 16px;transition:background .15s}
+.art-item:hover{background:rgba(255,255,255,.04)}
+.art-item a{color:var(--text);font-size:13px;font-weight:600;line-height:1.4;transition:color .15s}
+.art-item a:hover{color:var(--accent)}
+.art-meta{font-size:10px;color:var(--text3);margin-top:4px;display:flex;gap:12px}
+
+.loading{display:flex;align-items:center;justify-content:center;padding:60px;color:var(--text3);gap:10px;font-size:13px}
+.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.08);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+</style>
+</head>
+<body>
+
+<header class="bar">
+  <div class="brand" onclick="location.href='/'"><i></i> Pulse</div>
+  <div class="bar-right">
+    <button class="bar-btn" onclick="location.href='/globe'">Globe</button>
+    <button class="bar-btn" onclick="location.href='/'">Home</button>
+  </div>
+</header>
+
+<section class="hero">
+  <h1>Topic <span>Velocity</span></h1>
+  <p>See which topics are accelerating or fading in real-time. Track how the media agenda shifts hour by hour.</p>
+</section>
+
+<div class="controls">
+  <button class="ctrl-btn on" data-hours="48" onclick="setWindow(48)">48 Hours</button>
+  <button class="ctrl-btn" data-hours="24" onclick="setWindow(24)">24 Hours</button>
+  <button class="ctrl-btn" data-hours="72" onclick="setWindow(72)">72 Hours</button>
+  <button class="ctrl-btn" data-hours="168" onclick="setWindow(168)">7 Days</button>
+</div>
+
+<div class="content">
+  <div class="two-col" id="panels">
+    <div class="panel" id="risingPanel">
+      <div class="panel-head"><h3>Rising</h3><span class="badge badge-rising">Accelerating</span></div>
+      <div id="risingList"><div class="loading">Loading<span class="spinner"></span></div></div>
+    </div>
+    <div class="panel" id="decliningPanel">
+      <div class="panel-head"><h3>Declining</h3><span class="badge badge-declining">Decelerating</span></div>
+      <div id="decliningList"><div class="loading">Loading<span class="spinner"></span></div></div>
+    </div>
+  </div>
+
+  <div class="detail-section" id="detailSection" style="display:none">
+    <div class="detail-card">
+      <h3 id="detailTitle"></h3>
+      <div class="detail-sub" id="detailSub"></div>
+      <div class="detail-stats" id="detailStats"></div>
+      <div class="chart-wrap"><canvas id="timelineChart"></canvas></div>
+      <div class="articles-list" id="detailArticles"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+const CAT_COLORS = {conflict:'#ff6b6b',economy:'#ffc844',politics:'#7b8aff',health:'#2ee8a5',environment:'#22d4e6',technology:'#a78bfa',society:'#ff9f43',general:'#8899bb'};
+
+let currentWindow = 48;
+let allData = null;
+let selectedTheme = null;
+let timelineChart = null;
+
+async function init() {
+  await loadTopics();
+}
+
+async function loadTopics() {
+  try {
+    const res = await fetch(`/api/velocity/topics?hours=${currentWindow}&limit=25`);
+    allData = await res.json();
+    renderLists();
+  } catch (e) {
+    document.getElementById('risingList').innerHTML = '<div style="padding:40px;text-align:center;color:var(--text3)">Failed to load</div>';
+    document.getElementById('decliningList').innerHTML = '';
+  }
+}
+
+function renderLists() {
+  const maxTotal = Math.max(
+    ...allData.rising.map(t => t.total_count),
+    ...allData.declining.map(t => t.total_count),
+    1
+  );
+
+  document.getElementById('risingList').innerHTML = allData.rising.map((t, i) => topicRow(t, i + 1, maxTotal, true)).join('');
+  document.getElementById('decliningList').innerHTML = allData.declining.map((t, i) => topicRow(t, i + 1, maxTotal, false)).join('');
+}
+
+function topicRow(t, rank, maxTotal, isRising) {
+  const col = CAT_COLORS[t.category] || CAT_COLORS.general;
+  const velStr = t.velocity_pct >= 0 ? `+${t.velocity_pct}%` : `${t.velocity_pct}%`;
+  const barPct = Math.round(t.total_count / maxTotal * 100);
+  const barCol = isRising ? 'var(--rising)' : 'var(--declining)';
+  const active = selectedTheme === t.theme ? 'active' : '';
+
+  return `<div class="topic-row ${active}" onclick="selectTopic('${esc(t.theme)}')">
+    <span class="t-rank">${rank}</span>
+    <div class="t-info">
+      <div class="t-name">${humanTheme(t.theme)}</div>
+      <span class="t-cat" style="background:${col}22;color:${col}">${t.category}</span>
+    </div>
+    <div class="t-stats">
+      <span class="t-count">${t.total_count}</span>
+      <div class="t-bar-wrap"><div class="t-bar" style="width:${barPct}%;background:${barCol}"></div></div>
+      <span class="t-vel ${isRising ? 'up' : 'down'}">${velStr}</span>
+    </div>
+  </div>`;
+}
+
+function setWindow(hours) {
+  currentWindow = hours;
+  document.querySelectorAll('.ctrl-btn').forEach(b => b.classList.toggle('on', parseInt(b.dataset.hours) === hours));
+  selectedTheme = null;
+  document.getElementById('detailSection').style.display = 'none';
+  document.getElementById('risingList').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  document.getElementById('decliningList').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  loadTopics();
+}
+
+async function selectTopic(theme) {
+  selectedTheme = theme;
+  renderLists(); // highlight active
+
+  const section = document.getElementById('detailSection');
+  section.style.display = 'block';
+  document.getElementById('detailTitle').textContent = humanTheme(theme);
+  document.getElementById('detailSub').textContent = `Theme: ${theme}`;
+  document.getElementById('detailStats').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  document.getElementById('detailArticles').innerHTML = '';
+
+  try {
+    const res = await fetch(`/api/velocity/timeline?theme=${encodeURIComponent(theme)}&hours=${currentWindow}`);
+    const d = await res.json();
+    renderDetail(d);
+  } catch (e) {
+    document.getElementById('detailStats').innerHTML = '<div style="color:var(--text3)">Failed to load</div>';
+  }
+
+  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function renderDetail(d) {
+  const totalArticles = d.timeline.reduce((a, b) => a + b.count, 0);
+  const avgTone = d.timeline.filter(t => t.avg_tone != null);
+  const meanTone = avgTone.length > 0
+    ? (avgTone.reduce((a, b) => a + b.avg_tone * b.count, 0) / avgTone.reduce((a, b) => a + b.count, 0))
+    : 0;
+  const peakHour = d.timeline.reduce((a, b) => b.count > a.count ? b : a, { count: 0 });
+  const col = CAT_COLORS[d.category] || CAT_COLORS.general;
+
+  document.getElementById('detailStats').innerHTML = `
+    <div class="d-stat"><div class="d-stat-val">${totalArticles}</div><div class="d-stat-lbl">Total Articles</div></div>
+    <div class="d-stat"><div class="d-stat-val" style="color:${meanTone >= 0 ? 'var(--rising)' : 'var(--declining)'}">${meanTone >= 0 ? '+' : ''}${meanTone.toFixed(2)}</div><div class="d-stat-lbl">Avg Tone</div></div>
+    <div class="d-stat"><div class="d-stat-val">${peakHour.count}</div><div class="d-stat-lbl">Peak Hour</div></div>
+    <div class="d-stat"><div class="d-stat-val" style="color:${col}">${d.category}</div><div class="d-stat-lbl">Category</div></div>
+  `;
+
+  // Timeline chart
+  if (timelineChart) timelineChart.destroy();
+  const ctx = document.getElementById('timelineChart');
+  timelineChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: d.timeline.map(t => {
+        const dt = new Date(t.hour);
+        return dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) + ' ' +
+               dt.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+      }),
+      datasets: [{
+        label: 'Articles',
+        data: d.timeline.map(t => t.count),
+        borderColor: col,
+        backgroundColor: col + '22',
+        fill: true,
+        tension: 0.3,
+        pointRadius: 1.5,
+        pointHoverRadius: 5,
+        borderWidth: 2
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(13,17,39,.95)',
+          borderColor: 'rgba(255,255,255,.08)',
+          borderWidth: 1,
+          bodyFont: { family: "'JetBrains Mono'", size: 11 },
+          padding: 10,
+          cornerRadius: 8,
+          callbacks: { label: ctx => `${ctx.raw} articles` }
+        }
+      },
+      scales: {
+        x: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { size: 9 }, maxTicksLimit: 10, maxRotation: 45 } },
+        y: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 } }, beginAtZero: true }
+      }
+    }
+  });
+
+  // Recent articles
+  if (d.recent_articles.length > 0) {
+    document.getElementById('detailArticles').innerHTML = `<h4>Recent Articles</h4>` +
+      d.recent_articles.map(a => {
+        const ts = a.gdelt_timestamp ? new Date(a.gdelt_timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
+        const toneCol = a.tone_score != null ? (a.tone_score >= 0 ? 'var(--rising)' : 'var(--declining)') : 'var(--text3)';
+        return `<div class="art-item">
+          <a href="${esc(a.url)}" target="_blank">${esc(a.title)}</a>
+          <div class="art-meta">
+            <span>${esc(a.domain)}</span>
+            <span>${ts}</span>
+            ${a.tone_score != null ? `<span style="color:${toneCol};font-family:var(--mono);font-weight:700">${a.tone_score >= 0 ? '+' : ''}${a.tone_score.toFixed(1)}</span>` : ''}
+          </div>
+        </div>`;
+      }).join('');
+  }
+}
+
+function humanTheme(t) {
+  return t.replace(/^(WB_\d+_|USPEC_|ENV_|EPU_|TAX_|CRISISLEX_|GENERAL_|SOC_|UNGP_)/, '')
+          .replace(/_/g, ' ')
+          .toLowerCase()
+          .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function esc(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+init();
+</script>
+</body>
+</html>

--- a/src/gdelt_event_pipeline/config/settings.py
+++ b/src/gdelt_event_pipeline/config/settings.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from urllib.parse import quote_plus
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
 
 
 @dataclass(frozen=True)

--- a/src/gdelt_event_pipeline/config/settings.py
+++ b/src/gdelt_event_pipeline/config/settings.py
@@ -18,9 +18,7 @@ class DatabaseSettings:
     port: int = field(default_factory=lambda: int(os.environ.get("PGPORT", "5432")))
     user: str = field(default_factory=lambda: os.environ.get("PGUSER", "postgres"))
     password: str = field(default_factory=lambda: os.environ.get("PGPASSWORD", ""))
-    database: str = field(
-        default_factory=lambda: os.environ.get("PGDATABASE", "gdelt_pulse")
-    )
+    database: str = field(default_factory=lambda: os.environ.get("PGDATABASE", "gdelt_pulse"))
     url: str = field(default_factory=lambda: os.environ.get("DATABASE_URL", ""))
 
     @property
@@ -59,9 +57,7 @@ class ClusteringSettings:
 class ApiSettings:
     cors_origins: list[str] = field(
         default_factory=lambda: [
-            o.strip()
-            for o in os.environ.get("CORS_ORIGINS", "").split(",")
-            if o.strip()
+            o.strip() for o in os.environ.get("CORS_ORIGINS", "").split(",") if o.strip()
         ]
     )
 

--- a/src/gdelt_event_pipeline/config/settings.py
+++ b/src/gdelt_event_pipeline/config/settings.py
@@ -18,7 +18,9 @@ class DatabaseSettings:
     port: int = field(default_factory=lambda: int(os.environ.get("PGPORT", "5432")))
     user: str = field(default_factory=lambda: os.environ.get("PGUSER", "postgres"))
     password: str = field(default_factory=lambda: os.environ.get("PGPASSWORD", ""))
-    database: str = field(default_factory=lambda: os.environ.get("PGDATABASE", "gdelt_pulse"))
+    database: str = field(
+        default_factory=lambda: os.environ.get("PGDATABASE", "gdelt_pulse")
+    )
     url: str = field(default_factory=lambda: os.environ.get("DATABASE_URL", ""))
 
     @property
@@ -57,7 +59,9 @@ class ClusteringSettings:
 class ApiSettings:
     cors_origins: list[str] = field(
         default_factory=lambda: [
-            o.strip() for o in os.environ.get("CORS_ORIGINS", "").split(",") if o.strip()
+            o.strip()
+            for o in os.environ.get("CORS_ORIGINS", "").split(",")
+            if o.strip()
         ]
     )
 

--- a/src/gdelt_event_pipeline/normalization/normalize.py
+++ b/src/gdelt_event_pipeline/normalization/normalize.py
@@ -96,6 +96,7 @@ def normalize_row(row: list[str]) -> dict[str, Any] | None:
         "persons": json.dumps(persons) if persons else None,
         "all_names": json.dumps(all_names) if all_names else None,
         "tone": json.dumps(tone) if tone else None,
+        "raw_payload": json.dumps({f"col_{i}": v for i, v in enumerate(row)}),
     }
 
 


### PR DESCRIPTION
Adds 6 interactive analysis pages, all accessible from the homepage:

  - Narrative Polarization (/polarization) — Tone spread analysis per story cluster, bubble chart, per-source tone breakdown           
  - Geopolitical Gravity Map (/gravity) — D3 force-directed graph of country co-mentions, interactive node exploration
  - Attention Asymmetry (/asymmetry) — Treemap of coverage vs crisis ratio, scatter plot, country comparison table                     
  - Source DNA (/sources) — Media fingerprinting by tone, themes, geography. Bubble chart, sortable table, detail modal with timeline
  - Story Propagation (/propagation) — How stories spread across outlets over time. Source cascade, hourly histogram, chronological    
  timeline                                           
  - Topic Velocity (/velocity) — Rising/declining topics with velocity percentages, configurable time window, per-topic drill-down     
                                                                                                                                       
  Also adds:                             
  - python-dotenv for automatic .env loading in local dev                                                                              
  - Rate limiting on all new API endpoints               
  - Materialized views for geopolitical gravity queries (sql/002_gravity_views.sql)