### PR TITLE
feat: all analysis features + website redesign

### DIFF
--- a/src/gdelt_event_pipeline/api/app.py
+++ b/src/gdelt_event_pipeline/api/app.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from gdelt_event_pipeline.config.settings import get_settings
@@ -137,6 +138,8 @@ app.add_middleware(
     allow_methods=["GET"],
     allow_headers=["*"],
 )
+
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 
 # ── Rate limiting ────────────────────────────────────────────────────
@@ -1153,6 +1156,16 @@ def get_asymmetry():
                 """)
             overcovered = cur.fetchall()
 
+            # True distinct article count (articles can mention multiple countries)
+            cur.execute("""
+                SELECT COUNT(DISTINCT a.id) AS cnt
+                FROM articles a, jsonb_array_elements(a.locations) AS loc
+                WHERE a.locations IS NOT NULL
+                  AND loc->>'country_code' IS NOT NULL
+                  AND a.tone IS NOT NULL
+                """)
+            true_total_articles = cur.fetchone()["cnt"]
+
             # Underreported: clusters where MOST articles are crisis-tagged
             # but total coverage is low
             cur.execute("""
@@ -1190,8 +1203,10 @@ def get_asymmetry():
     # Build crisis map
     crisis_map = {r["code"]: r["crisis_articles"] for r in crisis_rows}
 
-    # Total articles for percentage calculation
-    total_articles = sum(c["article_count"] for c in countries)
+    # Use the true distinct count for the headline stat;
+    # per-country sum is kept for coverage_pct (share of mentions)
+    total_articles = true_total_articles
+    total_mentions = sum(c["article_count"] for c in countries)
 
     country_data = []
     for c in countries:
@@ -1201,7 +1216,7 @@ def get_asymmetry():
                 "code": c["code"],
                 "article_count": c["article_count"],
                 "coverage_pct": (
-                    round(c["article_count"] / total_articles * 100, 3) if total_articles else 0
+                    round(c["article_count"] / total_mentions * 100, 3) if total_mentions else 0
                 ),
                 "crisis_articles": crisis_count,
                 "crisis_ratio": (
@@ -1243,7 +1258,7 @@ def get_asymmetry():
 
 @app.get("/api/gravity/graph")
 def gravity_graph(
-    min_weight: int = Query(50, ge=10, le=5000, description="Minimum co-mention count for edges"),
+    min_weight: int = Query(50, ge=10, description="Minimum co-mention count for edges"),
     limit_edges: int = Query(80, ge=10, le=300, description="Max edges to return"),
 ):
     """Return country co-mention graph for the geopolitical gravity map.
@@ -1258,6 +1273,11 @@ def gravity_graph(
         from psycopg.rows import dict_row
 
         with conn.cursor(row_factory=dict_row) as cur:
+            # Max weight (for dynamic slider range)
+            cur.execute("SELECT MAX(weight) AS mw FROM mv_country_comentions")
+            max_weight_row = cur.fetchone()
+            max_weight = max_weight_row["mw"] if max_weight_row and max_weight_row["mw"] else 0
+
             # Edges from materialized view
             cur.execute(
                 """
@@ -1310,7 +1330,7 @@ def gravity_graph(
         for e in edges
     ]
 
-    return {"nodes": nodes, "edges": edge_list}
+    return {"nodes": nodes, "edges": edge_list, "max_weight": max_weight}
 
 
 @app.get("/api/gravity/country/{code}")

--- a/src/gdelt_event_pipeline/api/static/asymmetry.html
+++ b/src/gdelt_event_pipeline/api/static/asymmetry.html
@@ -6,382 +6,302 @@
 <title>Attention Asymmetry | GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
+/* ── Page-specific styles (supplement pulse.css) ─── */
 
-:root{
-  --bg:#050507;--bg-raised:#0c0c10;--surface:#111116;--surface-2:#17171d;
-  --surface-3:#1d1d25;--border:#222230;--border-dim:#1a1a24;
-  --text:#ededf0;--text-2:#b0b0be;--text-3:#6e6e82;
-  --primary:#7c6aef;--primary-light:#9d8ff5;--primary-dim:rgba(124,106,239,0.1);
-  --teal:#2dd4a8;--teal-dim:rgba(45,212,168,0.1);
-  --amber:#e5a63e;--amber-dim:rgba(229,166,62,0.1);
-  --rose:#e5637a;--rose-dim:rgba(229,99,122,0.1);
-  --glass-bg:rgba(17,17,22,0.4);--glass-border:rgba(255,255,255,0.06);
-  --glass-blur:20px;--ease:cubic-bezier(0.4,0,0.2,1);
-}
-
-body{
-  font-family:'DM Sans',-apple-system,sans-serif;
-  background:var(--bg);color:var(--text);
-  min-height:100vh;line-height:1.55;
-  -webkit-font-smoothing:antialiased;overflow-x:hidden;
-}
-
-::selection{background:var(--primary-dim);color:var(--primary-light)}
-::-webkit-scrollbar{width:6px}
-::-webkit-scrollbar-track{background:transparent}
-::-webkit-scrollbar-thumb{background:var(--border-dim);border-radius:3px}
-
-/* ── Top bar ──────────────────────────────────── */
-
-.topbar{
-  position:fixed;top:0;left:0;right:0;z-index:100;
-  display:flex;align-items:center;gap:16px;
-  padding:14px 24px;
-  background:rgba(5,5,7,0.8);backdrop-filter:blur(20px) saturate(1.6);
-  -webkit-backdrop-filter:blur(20px) saturate(1.6);
-  border-bottom:1px solid var(--glass-border);
-}
-
-.topbar-back{
-  display:inline-flex;align-items:center;gap:6px;
-  padding:6px 14px;border-radius:20px;
-  border:1px solid var(--border-dim);background:none;
-  color:var(--text-2);font-size:0.78rem;font-family:inherit;
-  font-weight:500;cursor:pointer;text-decoration:none;
-  transition:all 0.2s var(--ease);
-}
-.topbar-back:hover{color:var(--text);border-color:var(--border)}
-.topbar-back svg{width:14px;height:14px}
-
-.topbar-title{font-size:0.9rem;font-weight:600;letter-spacing:-0.02em}
-.topbar-title .accent{color:var(--primary-light)}
-
-/* ── Page ─────────────────────────────────────── */
-
-.page-wrap{max-width:1060px;margin:0 auto;padding:80px 24px 60px}
-
-.page-intro{
-  text-align:center;margin-bottom:40px;
-  animation:fadeUp 0.6s var(--ease) both;
-}
-
-.page-intro h1{
-  font-size:clamp(1.8rem,4vw,2.6rem);
-  font-weight:700;letter-spacing:-0.04em;margin-bottom:10px;
-}
-
-.page-intro h1 .accent{
-  background:linear-gradient(135deg,var(--amber),var(--primary-light),var(--rose));
-  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
-  background-clip:text;
-}
-
-.page-intro p{font-size:0.92rem;color:var(--text-3);max-width:560px;margin:0 auto}
-
-@keyframes fadeUp{
-  from{opacity:0;transform:translateY(18px)}
-  to{opacity:1;transform:translateY(0)}
-}
-
-/* ── Overview stats ───────────────────────────── */
-
-.ov-stats{
-  display:flex;gap:10px;margin-bottom:32px;
-  animation:fadeUp 0.6s var(--ease) 0.1s both;
-}
-
-.ov-stat{
-  flex:1;text-align:center;padding:18px 14px;
-  background:var(--glass-bg);backdrop-filter:blur(var(--glass-blur));
-  border:1px solid var(--glass-border);border-radius:14px;
-}
-
-.ov-stat-val{
-  font-family:'JetBrains Mono',monospace;
-  font-size:1.4rem;font-weight:600;margin-bottom:2px;
-}
-
-.ov-stat-label{
-  font-size:0.66rem;text-transform:uppercase;
-  letter-spacing:0.07em;color:var(--text-3);font-weight:500;
-}
-
-/* ── Charts ───────────────────────────────────── */
-
-.chart-section{
-  background:var(--surface);border:1px solid var(--border-dim);
-  border-radius:16px;padding:24px;margin-bottom:20px;
-  animation:fadeUp 0.6s var(--ease) both;
-}
-
-.chart-section h3{
-  font-size:0.72rem;text-transform:uppercase;
-  letter-spacing:0.07em;color:var(--text-3);
-  font-weight:600;margin-bottom:4px;
-}
-
-.chart-section .chart-sub{
-  font-size:0.78rem;color:var(--text-3);margin-bottom:16px;
-}
-
-.chart-container{position:relative;height:320px}
-.chart-container.tall{height:400px}
+body { padding-top: 56px; }
 
 /* ── Treemap ──────────────────────────────────── */
 
-.treemap-wrap{
-  position:relative;height:360px;border-radius:10px;
-  overflow:hidden;margin-bottom:8px;
+.treemap-wrap {
+  position: relative;
+  height: 360px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  margin-bottom: var(--sp-2);
 }
 
-.tm-cell{
-  position:absolute;border:1px solid rgba(5,5,7,0.6);
-  border-radius:4px;overflow:hidden;
-  display:flex;flex-direction:column;
-  align-items:center;justify-content:center;
-  cursor:pointer;transition:filter 0.2s,transform 0.15s;
-  text-align:center;padding:4px;
+.tm-cell {
+  position: absolute;
+  border: 1px solid rgba(9, 9, 11, 0.6);
+  border-radius: 3px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: filter 0.2s var(--ease), transform 0.15s var(--ease);
+  text-align: center;
+  padding: 4px;
 }
 
-.tm-cell:hover{filter:brightness(1.25);transform:scale(1.02);z-index:2}
-
-.tm-cell .tm-code{
-  font-family:'JetBrains Mono',monospace;
-  font-size:0.72rem;font-weight:600;color:rgba(255,255,255,0.9);
-  text-shadow:0 1px 3px rgba(0,0,0,0.5);
+.tm-cell:hover {
+  filter: brightness(1.25);
+  transform: scale(1.02);
+  z-index: 2;
 }
 
-.tm-cell .tm-count{
-  font-family:'JetBrains Mono',monospace;
-  font-size:0.6rem;color:rgba(255,255,255,0.6);
-  text-shadow:0 1px 3px rgba(0,0,0,0.5);
+.tm-cell .tm-code {
+  font-family: var(--font);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-/* ── Two column layout ────────────────────────── */
-
-.two-col{
-  display:grid;grid-template-columns:1fr 1fr;gap:16px;
-  margin-bottom:20px;
+.tm-cell .tm-count {
+  font-family: var(--font);
+  font-size: 0.625rem;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.6);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
 /* ── Story panels ─────────────────────────────── */
 
-.story-panel{
-  background:var(--surface);border:1px solid var(--border-dim);
-  border-radius:16px;padding:24px;
-  animation:fadeUp 0.6s var(--ease) both;
+.story-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
 }
 
-.story-panel h3{
-  font-size:0.72rem;text-transform:uppercase;
-  letter-spacing:0.07em;font-weight:600;margin-bottom:14px;
-  display:flex;align-items:center;gap:8px;
+.story-panel h3 {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+  margin-bottom: var(--sp-4);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
 }
 
-.story-panel h3 .dot{
-  width:8px;height:8px;border-radius:50%;flex-shrink:0;
+.story-panel h3 .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
-.story-card{
-  padding:12px 14px;background:var(--bg);
-  border:1px solid var(--border-dim);border-radius:10px;
-  margin-bottom:6px;transition:all 0.2s var(--ease);
+.story-card {
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: var(--sp-2);
+  transition: border-color var(--duration) var(--ease), background var(--duration) var(--ease);
 }
 
-.story-card:hover{border-color:rgba(124,106,239,0.3);background:var(--surface-2)}
-
-.story-title{
-  font-size:0.82rem;font-weight:500;line-height:1.35;
-  margin-bottom:4px;letter-spacing:-0.01em;
-  display:-webkit-box;-webkit-line-clamp:2;
-  -webkit-box-orient:vertical;overflow:hidden;
+.story-card:hover {
+  border-color: var(--border-hover);
+  background: var(--surface-2);
 }
 
-.story-meta{
-  display:flex;gap:10px;font-size:0.7rem;color:var(--text-3);
+.story-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.4;
+  margin-bottom: 4px;
+  letter-spacing: -0.01em;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.story-meta .mono{font-family:'JetBrains Mono',monospace}
-
-.story-badge{
-  font-family:'JetBrains Mono',monospace;
-  font-size:0.66rem;font-weight:600;
-  padding:3px 8px;border-radius:12px;
+.story-meta {
+  display: flex;
+  gap: var(--sp-3);
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  align-items: center;
 }
 
-.badge-over{color:var(--amber);background:var(--amber-dim)}
-.badge-under{color:var(--rose);background:var(--rose-dim)}
-
-/* ── Country table ────────────────────────────── */
-
-.country-table-wrap{
-  max-height:400px;overflow-y:auto;
-  border-radius:10px;
+.story-badge {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  padding: 2px 8px;
+  border-radius: 6px;
 }
 
-.country-table{
-  width:100%;border-collapse:collapse;font-size:0.8rem;
+.badge-over {
+  color: var(--warning);
+  background: rgba(251, 191, 36, 0.08);
 }
 
-.country-table th{
-  position:sticky;top:0;z-index:2;
-  padding:10px 12px;text-align:left;
-  font-size:0.64rem;text-transform:uppercase;
-  letter-spacing:0.06em;color:var(--text-3);
-  font-weight:600;background:var(--surface);
-  border-bottom:1px solid var(--border-dim);
+.badge-under {
+  color: var(--negative);
+  background: rgba(248, 113, 113, 0.08);
 }
 
-.country-table th.sortable{cursor:pointer;user-select:none}
-.country-table th.sortable:hover{color:var(--text-2)}
-.country-table th.sorted{color:var(--primary-light)}
+/* ── Country table additions ──────────────────── */
 
-.country-table td{
-  padding:8px 12px;border-bottom:1px solid rgba(34,34,48,0.3);
-  vertical-align:middle;
+.country-table-wrap {
+  max-height: 400px;
+  overflow-y: auto;
 }
 
-.country-table tr:hover td{background:var(--surface-2)}
-
-.country-table .mono{font-family:'JetBrains Mono',monospace}
-
-.coverage-bar{
-  display:inline-block;height:4px;border-radius:2px;
-  background:var(--primary);vertical-align:middle;
-  margin-left:6px;transition:width 0.4s var(--ease);
+.coverage-bar {
+  display: inline-block;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+  vertical-align: middle;
+  margin-left: 6px;
+  transition: width 0.4s var(--ease);
 }
 
-.crisis-bar{
-  display:inline-block;height:4px;border-radius:2px;
-  background:var(--rose);vertical-align:middle;
-  margin-left:6px;transition:width 0.4s var(--ease);
+.crisis-bar {
+  display: inline-block;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--negative);
+  vertical-align: middle;
+  margin-left: 6px;
+  transition: width 0.4s var(--ease);
 }
 
 /* ── Tooltip ──────────────────────────────────── */
 
-.tooltip{
-  position:fixed;z-index:200;
-  background:rgba(12,12,16,0.95);backdrop-filter:blur(16px);
-  -webkit-backdrop-filter:blur(16px);
-  border:1px solid var(--glass-border);
-  border-radius:12px;padding:14px 16px;
-  pointer-events:none;opacity:0;transition:opacity 0.15s;
-  max-width:240px;
+.tooltip {
+  position: fixed;
+  z-index: 200;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  max-width: 240px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 
-.tooltip.visible{opacity:1}
+.tooltip.visible { opacity: 1; }
 
-.tooltip-name{font-size:0.88rem;font-weight:600;margin-bottom:4px}
-
-.tooltip-row{
-  display:flex;justify-content:space-between;gap:16px;
-  font-size:0.74rem;color:var(--text-3);margin-bottom:2px;
+.tooltip-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 4px;
 }
 
-.tooltip-row .val{
-  font-family:'JetBrains Mono',monospace;
-  color:var(--text-2);font-weight:500;
+.tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 0.75rem;
+  color: var(--text-3);
+  margin-bottom: 2px;
 }
 
-/* ── Loading ──────────────────────────────────── */
-
-.loading{
-  text-align:center;padding:48px 20px;
-  color:var(--text-3);font-size:0.86rem;
+.tooltip-row .val {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-2);
+  font-weight: 500;
 }
-
-.spinner{
-  display:inline-block;width:16px;height:16px;
-  border:2px solid var(--border);border-top-color:var(--primary);
-  border-radius:50%;animation:spin 0.5s linear infinite;
-  margin-left:8px;vertical-align:middle;
-}
-
-@keyframes spin{to{transform:rotate(360deg)}}
 
 /* ── Responsive ───────────────────────────────── */
 
-@media(max-width:768px){
-  .page-wrap{padding:72px 14px 40px}
-  .ov-stats{flex-direction:column}
-  .two-col{grid-template-columns:1fr}
-  .treemap-wrap{height:280px}
+@media (max-width: 768px) {
+  .treemap-wrap { height: 280px; }
+  .stat-grid-4 { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 480px) {
+  .stat-grid-4 { grid-template-columns: 1fr; }
 }
 </style>
 </head>
 <body>
 
-<div class="topbar">
-  <a href="/" class="topbar-back">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
     GDELT Pulse
   </a>
-  <span class="topbar-title">Attention <span class="accent">Asymmetry</span></span>
-</div>
+</nav>
 
 <div class="tooltip" id="tooltip"></div>
 
-<div class="page-wrap">
+<div class="container">
   <div class="page-intro">
-    <h1>Attention <span class="accent">Asymmetry</span></h1>
+    <h1>Attention Asymmetry</h1>
     <p>Where the world looks vs. where crises happen. Comparing media attention with crisis intensity to find the blind spots.</p>
   </div>
 
-  <div class="ov-stats">
-    <div class="ov-stat"><div class="ov-stat-val" id="statTotal">--</div><div class="ov-stat-label">Total Articles</div></div>
-    <div class="ov-stat"><div class="ov-stat-val" id="statCountries">--</div><div class="ov-stat-label">Countries Covered</div></div>
-    <div class="ov-stat"><div class="ov-stat-val" id="statTopPct">--</div><div class="ov-stat-label">Top 5 Countries Share</div></div>
-    <div class="ov-stat"><div class="ov-stat-val" id="statGini">--</div><div class="ov-stat-label">Concentration Index</div></div>
+  <div class="stat-grid stat-grid-4" style="margin-bottom: var(--sp-6);">
+    <div class="stat-card">
+      <div class="stat-value t-num" id="statTotal">--</div>
+      <div class="stat-label">Total Articles</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value t-num" id="statCountries">--</div>
+      <div class="stat-label">Countries Covered</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value t-num" id="statTopPct">--</div>
+      <div class="stat-label">Top 5 Countries Share</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value t-num" id="statGini">--</div>
+      <div class="stat-label">Concentration Index</div>
+    </div>
   </div>
 
   <!-- Treemap: visual coverage distribution -->
-  <div class="chart-section" style="animation-delay:0.15s">
-    <h3>Coverage Distribution</h3>
-    <div class="chart-sub">Each block = one country. Size = article volume. Color = crisis intensity (red = high crisis ratio).</div>
+  <div class="card" style="margin-bottom: var(--sp-5);">
+    <h3 class="t-overline" style="margin-bottom: var(--sp-1);">Coverage Distribution</h3>
+    <p class="t-caption t-dim" style="margin-bottom: var(--sp-4);">Each block = one country. Size = article volume. Color = crisis ratio: grey (low) &rarr; orange (mid) &rarr; red (high).</p>
     <div class="treemap-wrap" id="treemap"></div>
   </div>
 
   <!-- Scatter: coverage vs crisis ratio -->
-  <div class="chart-section" style="animation-delay:0.2s">
-    <h3>The Blind Spot Map</h3>
-    <div class="chart-sub">Countries in the top-right are well-covered crisis zones. Bottom-right = crises that media is ignoring.</div>
+  <div class="card" style="margin-bottom: var(--sp-5);">
+    <h3 class="t-overline" style="margin-bottom: var(--sp-1);">The Blind Spot Map</h3>
+    <p class="t-caption t-dim" style="margin-bottom: var(--sp-4);">Countries in the top-right are well-covered crisis zones. Bottom-right = crises that media is ignoring.</p>
     <div class="chart-container tall"><canvas id="scatterChart"></canvas></div>
   </div>
 
   <!-- Overcovered vs Underreported -->
-  <div class="two-col">
-    <div class="story-panel" style="animation-delay:0.25s">
-      <h3><span class="dot" style="background:var(--amber)"></span> <span style="color:var(--amber)">Most Covered</span> Stories</h3>
+  <div class="two-col" style="margin-bottom: var(--sp-5);">
+    <div class="story-panel">
+      <h3><span class="dot" style="background:var(--warning)"></span> <span style="color:var(--warning)">Most Covered</span> Stories</h3>
       <div id="overcoveredList"><div class="loading"><span class="spinner"></span></div></div>
     </div>
-    <div class="story-panel" style="animation-delay:0.3s">
-      <h3><span class="dot" style="background:var(--rose)"></span> <span style="color:var(--rose)">Underreported</span> Crises</h3>
+    <div class="story-panel">
+      <h3><span class="dot" style="background:var(--negative)"></span> <span style="color:var(--negative)">Underreported</span> Crises</h3>
       <div id="underreportedList"><div class="loading"><span class="spinner"></span></div></div>
     </div>
   </div>
 
   <!-- Full country table -->
-  <div class="chart-section" style="animation-delay:0.35s">
-    <h3>All Countries</h3>
-    <div class="chart-sub">Click column headers to sort. Coverage % shows share of total articles.</div>
-    <div class="country-table-wrap">
-      <table class="country-table" id="countryTable">
-        <thead>
-          <tr>
-            <th class="sortable sorted" data-sort="articles" data-dir="desc">Country</th>
-            <th class="sortable" data-sort="articles" data-dir="desc">Articles</th>
-            <th class="sortable" data-sort="coverage" data-dir="desc">Coverage</th>
-            <th class="sortable" data-sort="crisis" data-dir="desc">Crisis Articles</th>
-            <th class="sortable" data-sort="ratio" data-dir="desc">Crisis Ratio</th>
-            <th class="sortable" data-sort="tone" data-dir="asc">Tone</th>
-          </tr>
-        </thead>
-        <tbody id="countryTbody"></tbody>
-      </table>
+  <div class="card" style="margin-bottom: var(--sp-7);">
+    <h3 class="t-overline" style="margin-bottom: var(--sp-1);">All Countries</h3>
+    <p class="t-caption t-dim" style="margin-bottom: var(--sp-4);">Click column headers to sort. Coverage % shows share of total articles.</p>
+    <div class="table-wrap">
+      <div class="country-table-wrap">
+        <table class="table" id="countryTable">
+          <thead>
+            <tr>
+              <th class="sortable sorted" data-sort="articles" data-dir="desc">Country</th>
+              <th class="sortable" data-sort="articles" data-dir="desc">Articles</th>
+              <th class="sortable" data-sort="coverage" data-dir="desc">Coverage</th>
+              <th class="sortable" data-sort="crisis" data-dir="desc">Crisis Articles</th>
+              <th class="sortable" data-sort="ratio" data-dir="desc">Crisis Ratio</th>
+              <th class="sortable" data-sort="tone" data-dir="asc">Tone</th>
+            </tr>
+          </thead>
+          <tbody id="countryTbody"></tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>
@@ -391,9 +311,9 @@ const API='/api';
 const $=s=>document.querySelector(s);
 const $$=s=>document.querySelectorAll(s);
 
-Chart.defaults.color='#6e6e82';
-Chart.defaults.borderColor='rgba(34,34,48,0.6)';
-Chart.defaults.font.family="'DM Sans',sans-serif";
+Chart.defaults.color='#63636e';
+Chart.defaults.borderColor='rgba(255,255,255,0.06)';
+Chart.defaults.font.family="'Inter',sans-serif";
 
 const COUNTRIES={
 US:["United States","\u{1F1FA}\u{1F1F8}"],UK:["United Kingdom","\u{1F1EC}\u{1F1E7}"],
@@ -491,10 +411,19 @@ function renderTreemap(data){
   rects.forEach((r,i)=>{
     const c=items[i];
     const crisisIntensity=c.crisis_ratio/maxCrisis;
-    // Color: neutral purple → red based on crisis ratio
-    const red=Math.round(124+131*crisisIntensity);
-    const green=Math.round(106-106*crisisIntensity);
-    const blue=Math.round(239-117*crisisIntensity);
+    // Color: slate grey (no crisis) → orange (mid) → deep red (high crisis)
+    let red,green,blue;
+    if(crisisIntensity<0.5){
+      const t=crisisIntensity*2;          // 0→1 in first half
+      red=Math.round(60+195*t);           // 60→255
+      green=Math.round(65+95*t);          // 65→160
+      blue=Math.round(80-80*t);           // 80→0
+    }else{
+      const t=(crisisIntensity-0.5)*2;    // 0→1 in second half
+      red=255;
+      green=Math.round(160-140*t);        // 160→20
+      blue=0;
+    }
     const bg=`rgb(${red},${green},${blue})`;
 
     const showLabel=r.w>40&&r.h>30;
@@ -586,7 +515,7 @@ function showTmTip(e,idx){
     <div class="tooltip-row"><span>Articles</span><span class="val">${c.article_count.toLocaleString()}</span></div>
     <div class="tooltip-row"><span>Coverage</span><span class="val">${c.coverage_pct.toFixed(2)}%</span></div>
     <div class="tooltip-row"><span>Crisis articles</span><span class="val">${c.crisis_articles.toLocaleString()}</span></div>
-    <div class="tooltip-row"><span>Crisis ratio</span><span class="val" style="color:${c.crisis_ratio>0.3?'var(--rose)':'var(--text-2)'}">${(c.crisis_ratio*100).toFixed(1)}%</span></div>
+    <div class="tooltip-row"><span>Crisis ratio</span><span class="val" style="color:${c.crisis_ratio>0.3?'var(--negative)':'var(--text-2)'}">${(c.crisis_ratio*100).toFixed(1)}%</span></div>
   `;
   tt.classList.add('visible');
   moveTip(e);
@@ -620,14 +549,14 @@ function renderScatter(data){
           _name:cName(c.code),
         })),
         backgroundColor:items.map(c=>{
-          if(c.crisis_ratio>0.4)return'rgba(229,99,122,0.6)';
-          if(c.crisis_ratio>0.2)return'rgba(229,166,62,0.5)';
-          return'rgba(124,106,239,0.4)';
+          if(c.crisis_ratio>0.4)return'rgba(248,113,113,0.5)';
+          if(c.crisis_ratio>0.2)return'rgba(251,191,36,0.4)';
+          return'rgba(139,139,245,0.35)';
         }),
         borderColor:items.map(c=>{
-          if(c.crisis_ratio>0.4)return'rgba(229,99,122,0.9)';
-          if(c.crisis_ratio>0.2)return'rgba(229,166,62,0.8)';
-          return'rgba(124,106,239,0.7)';
+          if(c.crisis_ratio>0.4)return'rgba(248,113,113,0.8)';
+          if(c.crisis_ratio>0.2)return'rgba(251,191,36,0.7)';
+          return'rgba(139,139,245,0.6)';
         }),
         borderWidth:1,
       }],
@@ -644,20 +573,24 @@ function renderScatter(data){
               return[`${p._name} (${p._code})`,`Articles: ${p.x.toLocaleString()}`,`Crisis ratio: ${p.y.toFixed(1)}%`];
             },
           },
-          backgroundColor:'rgba(12,12,16,0.95)',bodyColor:'#b0b0be',
-          borderColor:'rgba(255,255,255,0.08)',borderWidth:1,
+          backgroundColor:'#1a1a1e',bodyColor:'#a1a1aa',titleColor:'#fafafa',
+          borderColor:'rgba(255,255,255,0.06)',borderWidth:1,
           padding:12,cornerRadius:10,
+          bodyFont:{family:"'Inter',sans-serif"},
+          titleFont:{family:"'Inter',sans-serif"},
         },
       },
       scales:{
         x:{
           type:'logarithmic',
-          title:{display:true,text:'Article Count (log scale)',color:'#6e6e82',font:{size:11}},
-          grid:{color:'rgba(34,34,48,0.4)'},
+          title:{display:true,text:'Article Count (log scale)',color:'#63636e',font:{size:11,family:"'Inter',sans-serif"}},
+          grid:{color:'rgba(255,255,255,0.04)'},
+          ticks:{color:'#63636e',font:{family:"'Inter',sans-serif"}},
         },
         y:{
-          title:{display:true,text:'Crisis Ratio %',color:'#6e6e82',font:{size:11}},
-          grid:{color:'rgba(34,34,48,0.4)'},
+          title:{display:true,text:'Crisis Ratio %',color:'#63636e',font:{size:11,family:"'Inter',sans-serif"}},
+          grid:{color:'rgba(255,255,255,0.04)'},
+          ticks:{color:'#63636e',font:{family:"'Inter',sans-serif"}},
         },
       },
     },
@@ -706,14 +639,14 @@ function renderTable(data){
   const html=sorted.slice(0,100).map(c=>{
     const covW=Math.round(c.article_count/maxArticles*80);
     const criW=Math.round(c.crisis_articles/maxCrisis*60);
-    const tCol=c.avg_tone<-1?'var(--rose)':c.avg_tone>1?'var(--teal)':'var(--text-3)';
+    const tCol=c.avg_tone<-1?'var(--negative)':c.avg_tone>1?'var(--positive)':'var(--text-3)';
     return`<tr>
-      <td>${cFlag(c.code)} <strong>${esc(cName(c.code))}</strong> <span style="color:var(--text-3);font-size:0.7rem">${c.code}</span></td>
-      <td class="mono">${c.article_count.toLocaleString()}<span class="coverage-bar" style="width:${covW}px"></span></td>
-      <td class="mono">${c.coverage_pct.toFixed(2)}%</td>
-      <td class="mono">${c.crisis_articles.toLocaleString()}<span class="crisis-bar" style="width:${criW}px"></span></td>
-      <td class="mono" style="color:${c.crisis_ratio>0.3?'var(--rose)':'var(--text-2)'}">${(c.crisis_ratio*100).toFixed(1)}%</td>
-      <td class="mono" style="color:${tCol}">${c.avg_tone>0?'+':''}${c.avg_tone.toFixed(2)}</td>
+      <td>${cFlag(c.code)} <strong>${esc(cName(c.code))}</strong> <span style="color:var(--text-3);font-size:0.6875rem">${c.code}</span></td>
+      <td style="font-variant-numeric:tabular-nums">${c.article_count.toLocaleString()}<span class="coverage-bar" style="width:${covW}px"></span></td>
+      <td style="font-variant-numeric:tabular-nums">${c.coverage_pct.toFixed(2)}%</td>
+      <td style="font-variant-numeric:tabular-nums">${c.crisis_articles.toLocaleString()}<span class="crisis-bar" style="width:${criW}px"></span></td>
+      <td style="font-variant-numeric:tabular-nums;color:${c.crisis_ratio>0.3?'var(--negative)':'var(--text-2)'}">${(c.crisis_ratio*100).toFixed(1)}%</td>
+      <td style="font-variant-numeric:tabular-nums;color:${tCol}">${c.avg_tone>0?'+':''}${c.avg_tone.toFixed(2)}</td>
     </tr>`;
   }).join('');
 
@@ -734,7 +667,7 @@ function sortCountries(arr){
 }
 
 // Table header sorting
-$$('.country-table th.sortable').forEach(th=>{
+$$('.table th.sortable').forEach(th=>{
   th.addEventListener('click',()=>{
     const sort=th.dataset.sort;
     if(currentSort===sort){
@@ -743,7 +676,7 @@ $$('.country-table th.sortable').forEach(th=>{
       currentSort=sort;
       currentDir=th.dataset.dir||'desc';
     }
-    $$('.country-table th').forEach(h=>h.classList.remove('sorted'));
+    $$('.table th').forEach(h=>h.classList.remove('sorted'));
     th.classList.add('sorted');
     if(_data)renderTable(_data);
   });

--- a/src/gdelt_event_pipeline/api/static/globe.html
+++ b/src/gdelt_event_pipeline/api/static/globe.html
@@ -3,136 +3,110 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
-<meta name="theme-color" content="#0d1127">
-<title>Pulse</title>
+<meta name="theme-color" content="#09090b">
+<title>Globe — GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --bg:#0d1127;
-  --bg2:#131838;
-  --card:rgba(20,26,56,.82);
-  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
-  --text:#e8ecf8;
-  --text2:rgba(232,236,248,.55);
-  --text3:rgba(232,236,248,.3);
-  --accent:#2ee8a5;
-  --accent-soft:rgba(46,232,165,.1);
-  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
-  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
-  --society:#ff9f43;--general:#8899bb;
-  --loc:#60a5fa;--person:#ff6b6b;--org:#a78bfa;--theme:#ffc844;
-  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
-  --r:16px;
-}
-body{font-family:var(--sans);background:var(--bg);color:var(--text);height:100dvh;overflow:hidden;-webkit-font-smoothing:antialiased;user-select:none;touch-action:none;overscroll-behavior:none}
+/* ── Globe-specific overrides ──────────────────────────── */
+body{height:100dvh;overflow:hidden;user-select:none;touch-action:none;overscroll-behavior:none}
 
-/* ── TOP BAR ──────────────────── */
-.bar{position:fixed;top:0;left:0;right:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 22px;pointer-events:none}
-.bar>*{pointer-events:auto}
-.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em}
-.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
-@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
-
-/* ── FILTERS ──────────────────── */
+/* ── FILTERS (center tabs) ───────── */
 .flt{position:fixed;top:58px;left:50%;transform:translateX(-50%);z-index:100;display:flex;flex-direction:column;align-items:center;gap:6px}
-.flt-tabs{display:flex;gap:2px;background:rgba(20,26,56,.7);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid rgba(255,255,255,.06);border-radius:100px;padding:3px}
-.fb{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text3);padding:7px 18px;border-radius:100px;cursor:pointer;border:none;background:none;transition:all .25s}
-.fb:hover{color:var(--text2)}
-.fb.on{color:var(--text);background:var(--accent-soft)}
+.flt-tabs{display:flex;gap:var(--sp-1);background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-full);padding:3px}
+.fb{font-family:var(--font);font-size:0.75rem;font-weight:500;color:var(--text-3);padding:6px 16px;border-radius:var(--radius-full);cursor:pointer;border:none;background:none;transition:color var(--duration),background var(--duration)}
+.fb:hover{color:var(--text-2)}
+.fb.on{color:var(--text);background:var(--surface-3)}
 
-/* ── LANDING (left side) ──────── */
+/* ── LANDING (left side) ─────────── */
 .landing{position:fixed;top:50%;left:40px;transform:translateY(-55%);z-index:90;max-width:260px;pointer-events:none;transition:opacity .6s,transform .6s}
 .landing.away{opacity:0;transform:translateY(-55%) translateX(-30px);pointer-events:none}
-.landing-h{font-size:42px;font-weight:700;line-height:1.08;letter-spacing:-.04em;margin-bottom:14px;color:var(--text)}
-.landing-h span{color:var(--accent)}
-.landing-p{font-size:13px;font-weight:400;line-height:1.7;color:var(--text2)}
-.landing-mode{font-size:11px;font-weight:500;color:var(--accent);margin-top:14px;opacity:0;transition:opacity .4s}
+.landing-h{font-size:clamp(2rem, 4vw, 2.75rem);font-weight:600;line-height:1.08;letter-spacing:-0.035em;margin-bottom:14px;color:var(--text)}
+.landing-h span{color:var(--accent-text)}
+.landing-p{font-size:0.8125rem;font-weight:400;line-height:1.7;color:var(--text-3)}
+.landing-mode{font-size:0.6875rem;font-weight:500;color:var(--text-3);margin-top:14px;opacity:0;transition:opacity .4s}
 .landing-mode.vis{opacity:1}
 
-/* ── GLOBE ────────────────────── */
+/* ── GLOBE ───────────────────────── */
 .gl{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
 .gl svg{cursor:grab}.gl svg:active{cursor:grabbing}
 
-/* ── MARKERS ──────────────────── */
+/* ── MARKERS ─────────────────────── */
 .mk{cursor:pointer}
 .mk-wave{fill:none;opacity:0;animation:waveOut 3s ease-out infinite}
 .mk-wave.w2{animation-delay:1.5s}
 @keyframes waveOut{
-  0%{r:0;stroke-width:2;opacity:.45}
+  0%{r:0;stroke-width:2;opacity:.35}
   100%{r:24;stroke-width:.3;opacity:0}
 }
 .mk-glow{animation:glowB 3s ease-in-out infinite}
-@keyframes glowB{0%,100%{opacity:.08}50%{opacity:.2}}
+@keyframes glowB{0%,100%{opacity:.06}50%{opacity:.15}}
 .mk-core{transition:r .2s ease}
 
-/* ── BOTTOM TRAY ──────────────── */
-.tray{position:fixed;bottom:0;left:0;right:0;z-index:90;padding:0 16px 14px;display:flex;gap:8px;overflow-x:auto;scrollbar-width:none;mask-image:linear-gradient(90deg,transparent,#000 24px,#000 calc(100% - 24px),transparent);transition:transform .4s cubic-bezier(.4,0,.2,1),opacity .3s;touch-action:pan-x;-webkit-overflow-scrolling:touch}
+/* ── BOTTOM TRAY ─────────────────── */
+.tray{position:fixed;bottom:0;left:0;right:0;z-index:90;padding:0 16px 14px;display:flex;gap:8px;overflow-x:auto;scrollbar-width:none;mask-image:linear-gradient(90deg,transparent,#000 24px,#000 calc(100% - 24px),transparent);transition:transform .4s var(--ease),opacity .3s;touch-action:pan-x;-webkit-overflow-scrolling:touch}
 .tray::-webkit-scrollbar{display:none}
 .tray.hide{transform:translateY(90px);opacity:0;pointer-events:none}
 
-.cd{flex-shrink:0;width:210px;background:var(--card);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:14px;cursor:pointer;box-shadow:var(--card-sh);transition:all .3s cubic-bezier(.4,0,.2,1);opacity:0;animation:cdIn .4s ease forwards}
-.cd:hover{transform:translateY(-3px);background:rgba(30,38,72,.85);border-color:rgba(255,255,255,.09)}
-.cd.pick{border-color:var(--accent);background:rgba(46,232,165,.08)}
+.cd{flex-shrink:0;width:210px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:14px;cursor:pointer;transition:border-color var(--duration),background var(--duration);opacity:0;animation:cdIn .4s ease forwards}
+.cd:hover{border-color:var(--border-hover);background:var(--surface-2)}
+.cd.pick{border-color:var(--border-active);background:var(--surface-2)}
 @keyframes cdIn{to{opacity:1}}
-.cd-tag{display:flex;align-items:center;gap:4px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;margin-bottom:6px}
+.cd-tag{display:flex;align-items:center;gap:4px;font-size:0.6875rem;font-weight:500;text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px}
 .cd-dot{width:6px;height:6px;border-radius:50%}
-.cd-count{margin-left:auto;color:var(--text3);font-weight:500;font-size:9px;letter-spacing:.03em}
-.cd-h{font-size:13px;font-weight:600;line-height:1.35;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;margin-bottom:8px;color:var(--text)}
-.cd-f{font-size:10px;color:var(--text3);display:flex;justify-content:space-between}
+.cd-count{margin-left:auto;color:var(--text-3);font-weight:450;font-size:0.6875rem;letter-spacing:.03em}
+.cd-h{font-size:0.8125rem;font-weight:500;line-height:1.35;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;margin-bottom:8px;color:var(--text)}
+.cd-f{font-size:0.6875rem;color:var(--text-3);display:flex;justify-content:space-between}
 .cd-n{display:none}
 
-/* ── EVENT CARD (right side, small) ── */
-.ev{position:fixed;top:50%;right:20px;transform:translateY(-50%) translateX(20px);z-index:150;width:320px;max-height:75vh;background:rgba(16,20,48,.88);backdrop-filter:blur(24px);-webkit-backdrop-filter:blur(24px);border:1px solid rgba(255,255,255,.06);border-radius:var(--r);box-shadow:0 8px 48px rgba(0,0,0,.35);overflow:hidden;opacity:0;pointer-events:none;transition:opacity .35s,transform .4s cubic-bezier(.4,0,.2,1);display:flex;flex-direction:column}
+/* ── EVENT CARD (right side) ─────── */
+.ev{position:fixed;top:50%;right:20px;transform:translateY(-50%) translateX(20px);z-index:150;width:320px;max-height:75vh;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;opacity:0;pointer-events:none;transition:opacity .35s,transform .4s var(--ease);display:flex;flex-direction:column}
 .ev.on{opacity:1;pointer-events:auto;transform:translateY(-50%) translateX(0)}
-.ev-close{position:absolute;top:12px;right:12px;width:28px;height:28px;border-radius:50%;border:none;background:rgba(255,255,255,.06);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:16px;color:var(--text2);transition:background .2s;z-index:5}
-.ev-close:hover{background:rgba(255,255,255,.12)}
-.ev-body{padding:20px;overflow-y:auto;flex:1;scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.06) transparent;touch-action:pan-y;-webkit-overflow-scrolling:touch}
-.ev-cat{display:inline-flex;align-items:center;gap:5px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;margin-bottom:12px;padding:4px 10px;border-radius:100px}
-.ev-h{font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.02em;margin-bottom:10px}
+.ev-close{position:absolute;top:12px;right:12px;width:28px;height:28px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--surface-2);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:16px;color:var(--text-3);transition:color var(--duration),border-color var(--duration);z-index:5}
+.ev-close:hover{color:var(--text);border-color:var(--border-hover)}
+.ev-body{padding:20px;overflow-y:auto;flex:1;scrollbar-width:thin;scrollbar-color:var(--surface-3) transparent;touch-action:pan-y;-webkit-overflow-scrolling:touch}
+.ev-cat{display:inline-flex;align-items:center;gap:5px;font-size:0.6875rem;font-weight:500;text-transform:uppercase;letter-spacing:.06em;margin-bottom:12px;padding:4px 10px;border-radius:var(--radius-full)}
+.ev-h{font-size:1.0625rem;font-weight:600;line-height:1.3;letter-spacing:-.02em;margin-bottom:10px}
 .ev-meta{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:16px}
-.ev-pill{display:inline-flex;align-items:center;gap:4px;font-size:10px;font-weight:600;padding:4px 10px;border-radius:100px;border:1px solid rgba(255,255,255,.08)}
+.ev-pill{display:inline-flex;align-items:center;gap:4px;font-size:0.625rem;font-weight:500;padding:4px 10px;border-radius:var(--radius-full);border:1px solid var(--border)}
 .ev-pill svg{flex-shrink:0}
-.ev-src{margin-top:4px;padding:14px 0 0;border-top:1px solid rgba(255,255,255,.06)}
-.ev-src-lbl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-bottom:8px}
-.ev-src-link{display:block;font-size:12px;font-weight:500;color:var(--text2);text-decoration:none;line-height:1.4;margin-bottom:4px;transition:color .15s;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
+.ev-src{margin-top:4px;padding:14px 0 0;border-top:1px solid var(--border)}
+.ev-src-lbl{font-size:0.6875rem;font-weight:500;text-transform:uppercase;letter-spacing:.06em;color:var(--text-3);margin-bottom:8px}
+.ev-src-link{display:block;font-size:0.75rem;font-weight:450;color:var(--text-2);text-decoration:none;line-height:1.4;margin-bottom:4px;transition:color var(--duration);overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
 .ev-src-link:hover{color:var(--text)}
-.ev-src-d{font-size:10px;color:var(--text3)}
-.ev-cta{display:block;width:100%;margin-top:16px;padding:12px;border:none;border-radius:12px;font-family:var(--sans);font-size:13px;font-weight:700;cursor:pointer;background:var(--accent);color:var(--bg);text-align:center;text-decoration:none;transition:all .2s}
-.ev-cta:hover{opacity:.85;transform:translateY(-1px)}
+.ev-src-d{font-size:0.625rem;color:var(--text-3)}
+.ev-cta{display:block;width:100%;margin-top:16px;padding:10px;border:1px solid var(--border);border-radius:var(--radius);font-family:var(--font);font-size:0.8125rem;font-weight:500;cursor:pointer;background:var(--surface-2);color:var(--text-2);text-align:center;text-decoration:none;transition:all var(--duration)}
+.ev-cta:hover{color:var(--text);border-color:var(--border-hover)}
 
-/* ── TIMELINE ─────────────────── */
+/* ── TIMELINE ────────────────────── */
 .tl{position:fixed;bottom:0;left:0;right:0;z-index:95;padding:0 28px 22px;display:none;flex-direction:column;background:linear-gradient(0deg,var(--bg) 65%,transparent)}
 .tl.vis{display:flex}
-.tl-top{display:flex;justify-content:space-between;font-size:11px;color:var(--text2);margin-bottom:8px;font-weight:500}
-.tl-v{font-weight:700;color:var(--accent);font-variant-numeric:tabular-nums}
+.tl-top{display:flex;justify-content:space-between;font-size:0.6875rem;color:var(--text-2);margin-bottom:8px;font-weight:450}
+.tl-v{font-weight:600;color:var(--text);font-variant-numeric:tabular-nums}
 .tl-track{position:relative;height:34px;display:flex;align-items:center}
-.tl-rail{width:100%;height:3px;border-radius:2px;background:rgba(255,255,255,.06)}
-.tl-fill{position:absolute;left:0;top:50%;height:3px;border-radius:2px;background:var(--accent);transform:translateY(-50%);transition:width .1s}
+.tl-rail{width:100%;height:3px;border-radius:2px;background:var(--surface-3)}
+.tl-fill{position:absolute;left:0;top:50%;height:3px;border-radius:2px;background:var(--text-3);transform:translateY(-50%);transition:width .1s}
 .tl-mks{position:absolute;inset:0;pointer-events:none}
 .tl-mk{position:absolute;top:50%;width:7px;height:7px;border-radius:50%;transform:translate(-50%,-50%);border:1.5px solid var(--bg);transition:opacity .3s}
 .tl input[type=range]{position:absolute;top:0;left:0;width:100%;height:100%;-webkit-appearance:none;appearance:none;background:transparent;cursor:pointer;margin:0}
-.tl input::-webkit-slider-thumb{-webkit-appearance:none;width:20px;height:20px;border-radius:50%;background:var(--accent);box-shadow:0 0 14px rgba(46,232,165,.4);border:3px solid var(--bg)}
-.tl input::-moz-range-thumb{width:20px;height:20px;border-radius:50%;background:var(--accent);box-shadow:0 0 14px rgba(46,232,165,.4);border:3px solid var(--bg)}
+.tl input::-webkit-slider-thumb{-webkit-appearance:none;width:18px;height:18px;border-radius:50%;background:var(--text);border:3px solid var(--bg)}
+.tl input::-moz-range-thumb{width:18px;height:18px;border-radius:50%;background:var(--text);border:3px solid var(--bg)}
 
-/* ── LOADER ───────────────────── */
+/* ── LOADER ──────────────────────── */
 .ld{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;z-index:300;background:var(--bg);transition:opacity .6s}
 .ld.out{opacity:0;pointer-events:none}
-.ld-sp{width:24px;height:24px;border:2.5px solid rgba(255,255,255,.07);border-top-color:var(--accent);border-radius:50%;animation:sp .6s linear infinite;margin-bottom:12px}
-@keyframes sp{to{transform:rotate(360deg)}}
-.ld-t{font-size:12px;color:var(--text2)}
+.ld-sp{width:20px;height:20px;border:2px solid var(--surface-3);border-top-color:var(--text-3);border-radius:50%;animation:spin .6s linear infinite;margin-bottom:12px}
+.ld-t{font-size:0.75rem;color:var(--text-3)}
 
 @media(max-width:700px){
   body{overflow:hidden}
-  .bar{padding:10px 16px}
-  .brand{font-size:15px}
 
   /* Tabs: bottom tab bar, big touch targets */
   .flt{top:auto;bottom:0;left:0;right:0;transform:none;z-index:200;flex-direction:column;gap:0}
-  .flt-tabs{width:100%;justify-content:center;border-radius:0;border:none;border-top:1px solid rgba(255,255,255,.06);background:rgba(13,17,39,.95);padding:6px 8px;gap:0}
-  .fb{font-size:12px;padding:10px 0;flex:1;text-align:center;border-radius:0}
-  .fb.on{background:none;border-bottom:2px solid var(--accent)}
+  .flt-tabs{width:100%;justify-content:center;border-radius:0;border:none;border-top:1px solid var(--border);background:rgba(9,9,11,.95);padding:6px 8px;gap:0}
+  .fb{font-size:0.75rem;padding:10px 0;flex:1;text-align:center;border-radius:0}
+  .fb.on{background:none;border-bottom:2px solid var(--text)}
 
   /* Landing: below brand bar, doesn't overlap globe */
   .landing{left:0;right:0;max-width:none;top:38px;transform:none;text-align:center;padding:0 16px}
@@ -140,7 +114,7 @@ body{font-family:var(--sans);background:var(--bg);color:var(--text);height:100dv
   .landing-h{font-size:14px;margin-bottom:0;display:inline}
   .landing-h br{display:none}
   .landing-p{display:none}
-  .landing-mode{margin-top:2px;font-size:9px}
+  .landing-mode{margin-top:2px;font-size:0.5625rem}
 
   /* Globe: upper portion, SVG sized by JS to match container */
   .gl{inset:auto;position:fixed;top:75px;left:0;right:0;height:calc(45vh - 30px);bottom:auto;overflow:hidden}
@@ -150,21 +124,24 @@ body{font-family:var(--sans);background:var(--bg);color:var(--text);height:100dv
   .tray.hide{transform:translateY(20px);opacity:0}
   .cd{width:100%;flex-shrink:0;padding:12px;display:flex;flex-direction:row;align-items:center;gap:10px;animation:none;opacity:1}
   .cd:hover{transform:none}
-  .cd-tag{margin-bottom:0;font-size:8px;flex-shrink:0}
-  .cd-h{font-size:13px;margin-bottom:0;flex:1;-webkit-line-clamp:1}
+  .cd-tag{margin-bottom:0;font-size:0.5rem;flex-shrink:0}
+  .cd-h{font-size:0.8125rem;margin-bottom:0;flex:1;-webkit-line-clamp:1}
   .cd-f{display:none}
-  .cd-n{display:block;flex-shrink:0;font-size:11px;font-weight:600;color:var(--text3);white-space:nowrap}
+  .cd-n{display:block;flex-shrink:0;font-size:0.6875rem;font-weight:500;color:var(--text-3);white-space:nowrap}
 
   /* Event detail: bottom sheet */
-  .ev{right:0;left:0;width:100%;top:auto;bottom:52px;transform:translateY(100%);max-height:55vh;border-radius:var(--r) var(--r) 0 0}
+  .ev{right:0;left:0;width:100%;top:auto;bottom:52px;transform:translateY(100%);max-height:55vh;border-radius:var(--radius-lg) var(--radius-lg) 0 0}
   .ev.on{transform:translateY(0)}
   .ev-body{padding:16px}
-  .ev-h{font-size:15px}
+  .ev-h{font-size:0.9375rem}
   .ev-close{top:10px;right:10px;width:32px;height:32px;font-size:18px}
 
   /* Timeline */
   .tl{bottom:52px;padding:0 16px 16px}
   .tl input::-webkit-slider-thumb{width:22px;height:22px}
+
+  /* Hide topbar nav on mobile */
+  .topbar .topbar-nav{display:none}
 }
 </style>
 </head>
@@ -172,9 +149,14 @@ body{font-family:var(--sans);background:var(--bg);color:var(--text);height:100dv
 
 <div class="ld" id="ld"><div class="ld-sp"></div><div class="ld-t">Loading world events...</div></div>
 
-<div class="bar">
-  <div class="brand"><i></i>Pulse</div>
-</div>
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+  <div class="topbar-nav">
+  </div>
+</nav>
 
 <div class="flt" id="flt">
   <div class="flt-tabs">
@@ -217,10 +199,10 @@ body{font-family:var(--sans);background:var(--bg);color:var(--text);height:100dv
 (()=>{
 "use strict";
 
-const C={conflict:"#e74c4c",economy:"#e6a817",politics:"#5b6abf",health:"#1db88a",environment:"#1aafbf",technology:"#8b5cf6",society:"#e67e22",general:"#8893a7"};
+const C={conflict:"#f87171",economy:"#fbbf24",politics:"#818cf8",health:"#34d399",environment:"#22d3ee",technology:"#a78bfa",society:"#fb923c",general:"#71717a"};
 const L={conflict:"Conflict",economy:"Economy",politics:"Politics",health:"Health",environment:"Environment",technology:"Technology",society:"Society",general:"General"};
 const HINTS={live:"Showing the hottest stories right now",rising:"Showing stories gaining momentum",silent:"Showing big stories that went quiet",timeline:"Scrub through the last 6 hours"};
-const META_COL={loc:"#3b82f6",person:"#e74c4c",org:"#8b5cf6",theme:"#e6a817"};
+const META_COL={loc:"#60a5fa",person:"#f87171",org:"#a78bfa",theme:"#fbbf24"};
 
 let mode="live",data=[],allTL=[],act=null,countries=null;
 let proj,ph,svg,g,rot=[-10,-20,0],zm=1,autoR=true,af=null,W,H,R,mob=false,gW,gH;
@@ -246,15 +228,15 @@ function mkG(){
   svg=d3.select("#gl").append("svg").attr("width",gW).attr("height",mob?gH:H);
   const df=svg.append("defs");
 
-  // ocean gradient - deep indigo
+  // ocean gradient - dark, matching --bg / --surface
   const og=df.append("radialGradient").attr("id","oG").attr("cx","38%").attr("cy","30%");
-  og.append("stop").attr("offset","0%").attr("stop-color","#1a2254");
-  og.append("stop").attr("offset","100%").attr("stop-color","#0e1235");
+  og.append("stop").attr("offset","0%").attr("stop-color","#1a1a1e");
+  og.append("stop").attr("offset","100%").attr("stop-color","#0f0f11");
 
-  // atmosphere glow
+  // atmosphere glow - very subtle
   const ag=df.append("radialGradient").attr("id","aG").attr("cx","50%").attr("cy","50%");
   ag.append("stop").attr("offset","80%").attr("stop-color","transparent");
-  ag.append("stop").attr("offset","100%").attr("stop-color","rgba(46,232,165,.04)");
+  ag.append("stop").attr("offset","100%").attr("stop-color","rgba(139,139,245,.03)");
 
   // soft glow
   const fl=df.append("filter").attr("id","sg").attr("x","-200%").attr("y","-200%").attr("width","500%").attr("height","500%");
@@ -280,7 +262,7 @@ async function world(){
   const w=await r.json();
   countries=topojson.feature(w,w.objects.countries);
   g.select(".c-land").selectAll("path").data(countries.features).enter()
-    .append("path").attr("fill","#1e2755").attr("stroke","rgba(255,255,255,.045)").attr("stroke-width",.35);
+    .append("path").attr("fill","#1a1a1e").attr("stroke","rgba(255,255,255,.04)").attr("stroke-width",.35);
 }
 
 function draw(){
@@ -321,12 +303,12 @@ function dots(){
 
     // main dot
     cg.append("circle").attr("class","mk-core")
-      .attr("r",on?r+2:r).attr("fill",col).attr("opacity",on?1:.85)
-      .attr("stroke",on?"#fff":"rgba(255,255,255,.2)")
+      .attr("r",on?r+2:r).attr("fill",col).attr("opacity",on?1:.75)
+      .attr("stroke",on?"#fafafa":"rgba(255,255,255,.15)")
       .attr("stroke-width",on?2:1);
 
     // inner highlight
-    cg.append("circle").attr("r",Math.max(1,r*.3)).attr("fill","#fff").attr("opacity",.5);
+    cg.append("circle").attr("r",Math.max(1,r*.3)).attr("fill","#fafafa").attr("opacity",.4);
   });
 }
 
@@ -358,11 +340,11 @@ function mkCards(animate){
     let meta="";
     if(m==="rising"){
       const rc=c.recent_count||0;
-      meta=`<span style="color:#2ee8a5">▲ ${rc} new in 2h</span><span>${countLabel} total</span>`;
+      meta=`<span style="color:var(--positive)">+${rc} in 2h</span><span>${countLabel} total</span>`;
     }else if(m==="silent"){
       const sh=c.silent_hours?Math.round(c.silent_hours):0;
       const silentLabel=sh>=24?Math.round(sh/24)+"d quiet":sh+"h quiet";
-      meta=`<span style="color:#f59e0b">● ${silentLabel}</span><span>${countLabel} articles</span>`;
+      meta=`<span style="color:var(--warning)">${silentLabel}</span><span>${countLabel} articles</span>`;
     }else{
       const rc=c.recent_count||0;
       meta=`<span>${esc(c.location_name||c.country_code||"")}</span><span>${rc>0?rc+" in 2h · ":""}${countLabel} total</span>`;
@@ -431,7 +413,7 @@ function openEv(c){
   const pillsHtml=pills.map(p=>{
     // convert hex to rgba for border/bg
     const r=parseInt(p.color.slice(1,3),16),gr=parseInt(p.color.slice(3,5),16),b=parseInt(p.color.slice(5,7),16);
-    return `<span class="ev-pill" style="color:${p.color};border-color:rgba(${r},${gr},${b},.2);background:rgba(${r},${gr},${b},.08)">${p.icon}<span>${esc(p.label)}</span></span>`;
+    return `<span class="ev-pill" style="color:${p.color};border-color:rgba(${r},${gr},${b},.15);background:rgba(${r},${gr},${b},.06)">${p.icon}<span>${esc(p.label)}</span></span>`;
   }).join("");
 
   // Find the first article that has a URL
@@ -447,10 +429,10 @@ function openEv(c){
   }
 
   document.getElementById("ev-body").innerHTML=`
-    <div class="ev-cat" style="background:${col}12;color:${col}"><span class="cd-dot" style="background:${col};width:6px;height:6px;border-radius:50%"></span>${lbl}</div>
+    <div class="ev-cat" style="background:${col}0a;color:${col}"><span class="cd-dot" style="background:${col};width:6px;height:6px;border-radius:50%"></span>${lbl}</div>
     <h3 class="ev-h">${esc(c.title||"")}</h3>
     <div class="ev-meta">${pillsHtml}</div>
-    <div style="font-size:11px;color:var(--text3);margin-bottom:4px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+    <div style="font-size:0.6875rem;color:var(--text-3);margin-bottom:4px;display:flex;align-items:center;gap:12px;flex-wrap:wrap;font-variant-numeric:tabular-nums">
       <span style="display:flex;align-items:center;gap:4px"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7h16M4 12h16M4 17h16"/></svg>${c.article_count||0} articles</span>
       <span style="display:flex;align-items:center;gap:4px"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>Last updated ${ago(c.last_article_at)}</span>
     </div>

--- a/src/gdelt_event_pipeline/api/static/gravity.html
+++ b/src/gdelt_event_pipeline/api/static/gravity.html
@@ -6,344 +6,403 @@
 <title>Geopolitical Gravity | GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
+/* ── Page-specific overrides ─────────────────────── */
 
-:root{
-  --bg:#050507;--bg-raised:#0c0c10;--surface:#111116;--surface-2:#17171d;
-  --surface-3:#1d1d25;--border:#222230;--border-dim:#1a1a24;
-  --text:#ededf0;--text-2:#b0b0be;--text-3:#6e6e82;
-  --primary:#7c6aef;--primary-light:#9d8ff5;--primary-dim:rgba(124,106,239,0.1);
-  --teal:#2dd4a8;--teal-dim:rgba(45,212,168,0.1);
-  --amber:#e5a63e;--amber-dim:rgba(229,166,62,0.1);
-  --rose:#e5637a;--rose-dim:rgba(229,99,122,0.1);
-  --glass-bg:rgba(17,17,22,0.4);--glass-border:rgba(255,255,255,0.06);
-  --ease:cubic-bezier(0.4,0,0.2,1);
+body {
+  height: 100vh;
+  overflow: hidden;
+  line-height: 1.5;
 }
-
-body{
-  font-family:'DM Sans',-apple-system,sans-serif;
-  background:var(--bg);color:var(--text);
-  height:100vh;overflow:hidden;
-  -webkit-font-smoothing:antialiased;
-}
-
-::selection{background:var(--primary-dim);color:var(--primary-light)}
 
 /* ── Layout ───────────────────────────────────── */
 
-.app{display:flex;height:100vh}
-
-.graph-area{
-  flex:1;position:relative;overflow:hidden;
+.app {
+  display: flex;
+  height: 100vh;
+  padding-top: 56px; /* topbar height */
 }
 
-.sidebar{
-  width:380px;height:100vh;overflow-y:auto;
-  background:var(--bg-raised);
-  border-left:1px solid var(--border-dim);
-  display:flex;flex-direction:column;
-  transition:transform 0.35s var(--ease);
+.graph-area {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: var(--bg);
 }
 
-.sidebar.collapsed{transform:translateX(100%);width:0;min-width:0;border:none}
-
-.sidebar::-webkit-scrollbar{width:5px}
-.sidebar::-webkit-scrollbar-thumb{background:var(--border-dim);border-radius:3px}
-
-/* ── Top bar ──────────────────────────────────── */
-
-.topbar{
-  position:absolute;top:0;left:0;right:0;z-index:10;
-  display:flex;align-items:center;justify-content:space-between;
-  padding:16px 24px;
-  background:linear-gradient(180deg,rgba(5,5,7,0.9) 0%,transparent 100%);
-  pointer-events:none;
+.sidebar {
+  width: 380px;
+  height: 100%;
+  overflow-y: auto;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.35s var(--ease);
 }
 
-.topbar>*{pointer-events:auto}
-
-.topbar-left{display:flex;align-items:center;gap:16px}
-
-.topbar-back{
-  display:inline-flex;align-items:center;gap:6px;
-  padding:7px 14px;border-radius:20px;
-  border:1px solid var(--border-dim);background:var(--glass-bg);
-  backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
-  color:var(--text-2);font-size:0.78rem;font-family:inherit;
-  font-weight:500;cursor:pointer;text-decoration:none;
-  transition:all 0.2s var(--ease);
-}
-.topbar-back:hover{color:var(--text);border-color:var(--border)}
-.topbar-back svg{width:14px;height:14px}
-
-.topbar-title{
-  font-size:0.92rem;font-weight:600;letter-spacing:-0.02em;
-}
-.topbar-title .accent{color:var(--primary-light)}
-
-.topbar-controls{display:flex;align-items:center;gap:10px}
-
-.control-label{
-  font-size:0.7rem;color:var(--text-3);font-weight:500;
-  text-transform:uppercase;letter-spacing:0.06em;
+.sidebar.collapsed {
+  transform: translateX(100%);
+  width: 0;
+  min-width: 0;
+  border: none;
 }
 
-.control-slider{
-  width:120px;accent-color:var(--primary);
-  cursor:pointer;
+.sidebar::-webkit-scrollbar { width: 5px; }
+.sidebar::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: 3px; }
+
+/* ── Topbar controls ─────────────────────────── */
+
+.topbar-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.control-val{
-  font-family:'JetBrains Mono',monospace;
-  font-size:0.72rem;color:var(--text-2);min-width:30px;
+.control-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.control-slider {
+  width: 120px;
+  accent-color: var(--text-2);
+  cursor: pointer;
+  height: 4px;
+}
+
+.control-val {
+  font-family: var(--font);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+  color: var(--text-2);
+  min-width: 30px;
 }
 
 /* ── Graph SVG ────────────────────────────────── */
 
-.graph-svg{width:100%;height:100%;cursor:grab}
-.graph-svg:active{cursor:grabbing}
+.graph-svg { width: 100%; height: 100%; cursor: grab; }
+.graph-svg:active { cursor: grabbing; }
 
-.graph-svg .link{
-  stroke:rgba(124,106,239,0.15);
-  stroke-linecap:round;
-  transition:stroke 0.2s,stroke-opacity 0.2s;
+.graph-svg .link {
+  stroke: rgba(161, 161, 170, 0.10);
+  stroke-linecap: round;
+  transition: stroke 0.2s, stroke-opacity 0.2s;
 }
 
-.graph-svg .link.highlighted{
-  stroke:var(--primary-light);stroke-opacity:0.6;
+.graph-svg .link.highlighted {
+  stroke: var(--text-2);
+  stroke-opacity: 0.5;
 }
 
-.graph-svg .link.dimmed{stroke-opacity:0.04}
+.graph-svg .link.dimmed { stroke-opacity: 0.03; }
 
-.graph-svg .node-circle{
-  cursor:pointer;
-  transition:r 0.2s var(--ease),opacity 0.2s;
+.graph-svg .node-circle {
+  cursor: pointer;
+  transition: r 0.2s var(--ease), opacity 0.2s;
 }
 
-.graph-svg .node-circle.dimmed{opacity:0.15}
+.graph-svg .node-circle.dimmed { opacity: 0.15; }
 
-.graph-svg .node-label{
-  font-family:'JetBrains Mono',monospace;
-  font-size:10px;font-weight:500;
-  fill:var(--text-2);
-  pointer-events:none;
-  text-anchor:middle;
-  transition:opacity 0.2s;
+.graph-svg .node-label {
+  font-family: var(--font);
+  font-variant-numeric: tabular-nums;
+  font-size: 10px;
+  font-weight: 500;
+  fill: var(--text-3);
+  pointer-events: none;
+  text-anchor: middle;
+  transition: opacity 0.2s;
 }
 
-.graph-svg .node-label.dimmed{opacity:0.1}
+.graph-svg .node-label.dimmed { opacity: 0.1; }
 
 /* ── Tooltip ──────────────────────────────────── */
 
-.tooltip{
-  position:absolute;z-index:50;
-  background:rgba(12,12,16,0.95);
-  backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
-  border:1px solid var(--glass-border);
-  border-radius:12px;padding:14px 16px;
-  pointer-events:none;opacity:0;
-  transition:opacity 0.15s;
-  max-width:260px;
+.graph-tooltip {
+  position: absolute;
+  z-index: 100;
+  pointer-events: none;
+  padding: 12px 16px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  opacity: 0;
+  transition: opacity 0.15s;
+  max-width: 260px;
+  font-size: 0.75rem;
+  color: var(--text-2);
 }
 
-.tooltip.visible{opacity:1}
+.graph-tooltip.visible { opacity: 1; }
 
-.tooltip-name{
-  font-size:0.88rem;font-weight:600;margin-bottom:4px;
-  letter-spacing:-0.01em;
+.tooltip-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+  letter-spacing: -0.01em;
 }
 
-.tooltip-row{
-  display:flex;justify-content:space-between;gap:16px;
-  font-size:0.74rem;color:var(--text-3);margin-bottom:2px;
+.tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 0.75rem;
+  color: var(--text-3);
+  margin-bottom: 2px;
 }
 
-.tooltip-row .val{
-  font-family:'JetBrains Mono',monospace;
-  color:var(--text-2);font-weight:500;
+.tooltip-row .val {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-2);
+  font-weight: 500;
 }
 
 /* ── Sidebar content ──────────────────────────── */
 
-.sidebar-header{
-  padding:24px 24px 16px;
-  border-bottom:1px solid var(--border-dim);
-  position:sticky;top:0;z-index:2;
-  background:var(--bg-raised);
+.sidebar-header {
+  padding: 24px 24px 16px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--surface);
 }
 
-.sidebar-header h2{
-  font-size:1.05rem;font-weight:600;letter-spacing:-0.02em;
-  margin-bottom:2px;
+.sidebar-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 2px;
+  color: var(--text);
 }
 
-.sidebar-header p{font-size:0.76rem;color:var(--text-3)}
-
-.sidebar-empty{
-  padding:48px 24px;text-align:center;
-  color:var(--text-3);font-size:0.84rem;
+.sidebar-header p {
+  font-size: 0.75rem;
+  color: var(--text-3);
 }
 
-.sidebar-section{padding:20px 24px}
+.sidebar-empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-3);
+  font-size: 0.8125rem;
+}
 
-.sidebar-section h3{
-  font-size:0.68rem;text-transform:uppercase;
-  letter-spacing:0.07em;color:var(--text-3);
-  font-weight:600;margin-bottom:12px;
+.sidebar-section { padding: 20px 24px; }
+
+.sidebar-section h3 {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  font-weight: 500;
+  margin-bottom: 12px;
 }
 
 /* Stats row */
-.detail-stats{display:flex;gap:8px;margin-bottom:20px}
+.detail-stats { display: flex; gap: 8px; margin-bottom: 20px; }
 
-.d-stat{
-  flex:1;text-align:center;padding:12px 8px;
-  background:var(--surface);border:1px solid var(--border-dim);
-  border-radius:10px;
+.d-stat {
+  flex: 1;
+  text-align: center;
+  padding: 12px 8px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 
-.d-stat-val{
-  font-family:'JetBrains Mono',monospace;
-  font-size:1rem;font-weight:600;margin-bottom:1px;
+.d-stat-val {
+  font-variant-numeric: tabular-nums;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 1px;
 }
 
-.d-stat-label{
-  font-size:0.58rem;text-transform:uppercase;
-  letter-spacing:0.06em;color:var(--text-3);font-weight:500;
+.d-stat-label {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  font-weight: 500;
 }
 
 /* Connection rows */
-.conn-row{
-  display:flex;align-items:center;gap:10px;
-  padding:9px 0;
-  border-bottom:1px solid rgba(34,34,48,0.3);
-  cursor:pointer;
-  transition:background 0.15s;
-  margin:0 -8px;padding-left:8px;padding-right:8px;
-  border-radius:8px;
+.conn-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 8px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+  margin: 0 -8px;
+  border-radius: var(--radius-sm);
 }
 
-.conn-row:last-child{border-bottom:none}
-.conn-row:hover{background:var(--surface)}
+.conn-row:last-child { border-bottom: none; }
+.conn-row:hover { background: var(--surface-2); }
 
-.conn-flag{font-size:1.1rem;min-width:24px;text-align:center}
+.conn-flag { font-size: 1.1rem; min-width: 24px; text-align: center; }
 
-.conn-name{
-  flex:1;font-size:0.82rem;font-weight:500;
-  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+.conn-name {
+  flex: 1;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.conn-bar-wrap{width:80px;height:4px;background:var(--surface-3);border-radius:2px;overflow:hidden}
+.conn-bar-wrap {
+  width: 80px;
+  height: 4px;
+  background: var(--surface-3);
+  border-radius: 2px;
+  overflow: hidden;
+}
 
-.conn-bar{height:100%;border-radius:2px;background:var(--primary);transition:width 0.4s var(--ease)}
+.conn-bar {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--text-3);
+  transition: width 0.4s var(--ease);
+}
 
-.conn-val{
-  font-family:'JetBrains Mono',monospace;
-  font-size:0.7rem;color:var(--text-3);min-width:40px;
-  text-align:right;
+.conn-val {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  min-width: 40px;
+  text-align: right;
 }
 
 /* Cluster cards in sidebar */
-.s-cluster{
-  padding:12px;background:var(--surface);
-  border:1px solid var(--border-dim);border-radius:10px;
-  margin-bottom:6px;transition:all 0.2s var(--ease);
+.s-cluster {
+  padding: 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  transition: border-color var(--duration) var(--ease);
 }
 
-.s-cluster:hover{border-color:rgba(124,106,239,0.3);background:var(--surface-2)}
+.s-cluster:hover { border-color: var(--border-hover); }
 
-.s-cluster-title{
-  font-size:0.82rem;font-weight:500;line-height:1.35;
-  margin-bottom:4px;letter-spacing:-0.01em;
+.s-cluster-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: -0.01em;
 }
 
-.s-cluster-meta{
-  font-size:0.7rem;color:var(--text-3);
-  display:flex;gap:10px;
+.s-cluster-meta {
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  display: flex;
+  gap: 10px;
 }
 
-.s-cluster-meta .mono{font-family:'JetBrains Mono',monospace}
+.s-cluster-meta .mono {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
 
 /* ── Legend ────────────────────────────────────── */
 
-.legend{
-  position:absolute;bottom:20px;left:20px;z-index:10;
-  background:var(--glass-bg);backdrop-filter:blur(16px);
-  -webkit-backdrop-filter:blur(16px);
-  border:1px solid var(--glass-border);
-  border-radius:12px;padding:14px 16px;
-  font-size:0.7rem;color:var(--text-3);
+.legend {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  z-index: 10;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  font-size: 0.6875rem;
+  color: var(--text-3);
 }
 
-.legend-title{
-  font-size:0.62rem;text-transform:uppercase;
-  letter-spacing:0.07em;font-weight:600;margin-bottom:8px;
-  color:var(--text-3);
+.legend-title {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: var(--text-3);
 }
 
-.legend-item{display:flex;align-items:center;gap:8px;margin-bottom:4px}
-.legend-item:last-child{margin-bottom:0}
-
-.legend-circle{border-radius:50%;flex-shrink:0}
+.legend-item { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+.legend-item:last-child { margin-bottom: 0; }
+.legend-circle { border-radius: 50%; flex-shrink: 0; }
 
 /* ── Loading ──────────────────────────────────── */
 
-.loading-overlay{
-  position:absolute;inset:0;z-index:20;
-  display:flex;flex-direction:column;
-  align-items:center;justify-content:center;
-  background:var(--bg);
-  transition:opacity 0.4s;
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  transition: opacity 0.4s;
 }
 
-.loading-overlay.hidden{opacity:0;pointer-events:none}
+.loading-overlay.hidden { opacity: 0; pointer-events: none; }
 
-.loading-text{
-  font-size:0.88rem;color:var(--text-3);margin-top:16px;
+.loading-text {
+  font-size: 0.8125rem;
+  color: var(--text-3);
+  margin-top: 16px;
 }
-
-.spinner{
-  width:24px;height:24px;
-  border:2px solid var(--border);border-top-color:var(--primary);
-  border-radius:50%;animation:spin 0.6s linear infinite;
-}
-
-@keyframes spin{to{transform:rotate(360deg)}}
 
 /* ── Responsive ───────────────────────────────── */
 
-@media(max-width:768px){
-  .sidebar{
-    position:fixed;right:0;top:0;bottom:0;
-    width:320px;z-index:30;
-    box-shadow:-8px 0 32px rgba(0,0,0,0.5);
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    right: 0;
+    top: 56px;
+    bottom: 0;
+    width: 320px;
+    z-index: 30;
+    box-shadow: -8px 0 32px rgba(0, 0, 0, 0.5);
   }
-  .topbar-controls{display:none}
+  .topbar-controls { display: none; }
 }
 </style>
 </head>
 <body>
 
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+  <div class="topbar-nav">
+    <div class="topbar-controls">
+      <span class="control-label">Density</span>
+      <input type="range" class="control-slider" id="densitySlider" min="20" max="100" value="50" step="100">
+      <span class="control-val" id="densityVal">50</span>
+    </div>
+  </div>
+</nav>
+
 <div class="app">
   <div class="graph-area">
-    <!-- Top bar -->
-    <div class="topbar">
-      <div class="topbar-left">
-        <a href="/" class="topbar-back">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
-          Pulse
-        </a>
-        <span class="topbar-title">Geopolitical <span class="accent">Gravity</span></span>
-      </div>
-      <div class="topbar-controls">
-        <span class="control-label">Density</span>
-        <input type="range" class="control-slider" id="densitySlider" min="20" max="500" value="50" step="10">
-        <span class="control-val" id="densityVal">50</span>
-      </div>
-    </div>
-
     <!-- Loading -->
     <div class="loading-overlay" id="loadingOverlay">
       <div class="spinner"></div>
@@ -354,15 +413,15 @@ body{
     <svg class="graph-svg" id="graphSvg"></svg>
 
     <!-- Tooltip -->
-    <div class="tooltip" id="tooltip"></div>
+    <div class="graph-tooltip" id="tooltip"></div>
 
     <!-- Legend -->
     <div class="legend">
       <div class="legend-title">Node Size = Coverage Volume</div>
-      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--teal)"></div><span>Positive avg tone</span></div>
+      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--positive)"></div><span>Positive avg tone</span></div>
       <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--text-3)"></div><span>Neutral tone</span></div>
-      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--rose)"></div><span>Negative avg tone</span></div>
-      <div class="legend-item" style="margin-top:6px"><div style="width:30px;height:2px;background:var(--primary);border-radius:1px"></div><span>Co-mention link</span></div>
+      <div class="legend-item"><div class="legend-circle" style="width:8px;height:8px;background:var(--negative)"></div><span>Negative avg tone</span></div>
+      <div class="legend-item" style="margin-top:6px"><div style="width:30px;height:2px;background:var(--text-3);border-radius:1px"></div><span>Co-mention link</span></div>
     </div>
   </div>
 
@@ -432,9 +491,9 @@ function cFlag(code){return COUNTRIES[code]?COUNTRIES[code][1]:"\u{1F310}"}
 function esc(s){const d=document.createElement('div');d.textContent=String(s);return d.innerHTML}
 
 function toneColor(t){
-  if(t<-1)return'#e5637a';
-  if(t>1)return'#2dd4a8';
-  return'#6e6e82';
+  if(t<-1)return'#f87171';
+  if(t>1)return'#34d399';
+  return'#63636e';
 }
 
 // ── Graph state ──────────────────────────────────
@@ -452,6 +511,14 @@ async function loadGraph(minWeight){
       if(!r.ok)throw new Error(`Server ${r.status}`);
       return r.json();
     });
+
+    // Update slider max to the heaviest edge in the DB
+    if(data.max_weight){
+      const slider=$('#densitySlider');
+      slider.max=data.max_weight;
+      // Adjust step to ~1% of range
+      slider.step=Math.max(1,Math.round(data.max_weight/100));
+    }
 
     nodes=data.nodes.map(n=>({...n,name:cName(n.id),flag:cFlag(n.id)}));
     links=data.edges.map(e=>({source:e.source,target:e.target,weight:e.weight}));

--- a/src/gdelt_event_pipeline/api/static/index.html
+++ b/src/gdelt_event_pipeline/api/static/index.html
@@ -6,480 +6,239 @@
 <title>GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
+/* ── Page transitions ─────────────────────────────── */
+.page { display: none; min-height: 100vh; }
+.page.active { display: block; animation: slideUp 0.45s var(--ease) both; }
 
-:root {
-  --bg: #050507;
-  --bg-raised: #0c0c10;
-  --surface: #111116;
-  --surface-2: #17171d;
-  --surface-3: #1d1d25;
-  --border: #222230;
-  --border-dim: #1a1a24;
-  --text: #ededf0;
-  --text-2: #b0b0be;
-  --text-3: #6e6e82;
-  --primary: #7c6aef;
-  --primary-light: #9d8ff5;
-  --primary-dim: rgba(124, 106, 239, 0.1);
-  --primary-glow: rgba(124, 106, 239, 0.06);
-  --teal: #2dd4a8;
-  --teal-dim: rgba(45, 212, 168, 0.1);
-  --amber: #e5a63e;
-  --amber-dim: rgba(229, 166, 62, 0.1);
-  --rose: #e5637a;
-  --rose-dim: rgba(229, 99, 122, 0.1);
-  --glass-bg: rgba(17, 17, 22, 0.4);
-  --glass-border: rgba(255, 255, 255, 0.06);
-  --glass-blur: 20px;
-  --ease: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-body {
-  font-family: 'DM Sans', -apple-system, sans-serif;
-  background: var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  line-height: 1.55;
-  -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
-}
-
-::selection { background: var(--primary-dim); color: var(--primary-light); }
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 3px; }
-
-.glass {
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(1.6);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(1.6);
-  border: 1px solid var(--glass-border);
-}
-
-/* ── Back button (inner pages) ─────────────────────── */
-
-.back-btn {
-  position: fixed;
-  top: 18px;
-  left: 22px;
-  z-index: 100;
-  display: none;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border-radius: 22px;
-  border: none;
-  font-family: inherit;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--text-2);
-  cursor: pointer;
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px) saturate(1.6);
-  -webkit-backdrop-filter: blur(16px) saturate(1.6);
-  border: 1px solid var(--glass-border);
-  transition: all 0.25s var(--ease);
-}
-
-.back-btn:hover { color: var(--text); border-color: rgba(255,255,255,0.12); }
-.back-btn svg { width: 14px; height: 14px; }
-.back-btn.visible { display: inline-flex; }
-
-/* ── Pages ─────────────────────────────────────────── */
-
-.page {
-  display: none;
-  min-height: 100vh;
-}
-
-.page.active {
-  display: block;
-  animation: pageIn 0.5s var(--ease);
-}
-
-@keyframes pageIn {
-  from { opacity: 0; transform: translateY(16px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* ── LANDING ───────────────────────────────────────── */
-
+/* ── Landing ──────────────────────────────────────── */
 .landing {
   min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Ambient glow */
-.landing::before {
-  content: '';
-  position: fixed;
-  top: -40%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 140%;
-  height: 80%;
-  background: radial-gradient(ellipse 50% 60% at 50% 20%, rgba(124, 106, 239, 0.07) 0%, transparent 70%);
-  pointer-events: none;
-  z-index: 0;
-}
-
-.hero {
-  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 60px 24px 40px;
-  position: relative;
-  z-index: 1;
+  padding: var(--sp-5);
 }
 
-.hero h1 {
-  font-size: clamp(2.8rem, 7vw, 5rem);
-  font-weight: 700;
-  letter-spacing: -0.05em;
-  line-height: 1.05;
-  margin-bottom: 20px;
-  animation: heroText 0.8s var(--ease) both;
-}
-
-@keyframes heroText {
-  from { opacity: 0; transform: translateY(24px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.hero h1 .accent {
-  background: linear-gradient(135deg, var(--primary-light), #b8a5ff);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.hero-sub {
-  font-size: clamp(1rem, 2.2vw, 1.2rem);
-  color: var(--text-3);
-  max-width: 500px;
-  margin-bottom: 40px;
-  font-weight: 400;
-  animation: heroText 0.8s var(--ease) 0.15s both;
-}
-
-.hero-buttons {
-  display: flex;
-  gap: 14px;
-  animation: heroText 0.8s var(--ease) 0.3s both;
-}
-
-.hero-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 16px 36px;
-  border: none;
-  border-radius: 16px;
-  font-size: 0.95rem;
-  font-family: inherit;
+.landing-title {
+  font-size: clamp(3.2rem, 8vw, 6rem);
   font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s var(--ease);
-  position: relative;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  margin-bottom: var(--sp-4);
+  animation: slideUp 0.6s var(--ease) both;
+}
+
+.landing-title span {
+  color: var(--text-3);
+}
+
+.landing-sub {
+  font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
+  color: var(--text-3);
+  max-width: 400px;
+  margin-bottom: var(--sp-7);
+  font-weight: 400;
+  animation: slideUp 0.6s var(--ease) 0.08s both;
+}
+
+.landing-actions {
+  display: flex;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-9);
+  animation: slideUp 0.6s var(--ease) 0.16s both;
+}
+
+/* ── Feature grid ─────────────────────────────────── */
+.features {
+  width: 100%;
+  max-width: 680px;
+  animation: slideUp 0.6s var(--ease) 0.24s both;
+}
+
+.features-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-bottom: var(--sp-4);
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
-.hero-btn svg { width: 18px; height: 18px; flex-shrink: 0; }
-
-.hero-btn-primary {
-  background: var(--primary);
-  color: white;
-  box-shadow: 0 4px 30px rgba(124, 106, 239, 0.25);
-}
-
-.hero-btn-primary:hover {
-  background: var(--primary-light);
-  box-shadow: 0 8px 40px rgba(124, 106, 239, 0.4);
-  transform: translateY(-2px);
-}
-
-.hero-btn-primary:active { transform: translateY(0); }
-
-.hero-btn-glass {
-  color: var(--text-2);
-  background: var(--glass-bg);
-  backdrop-filter: blur(20px) saturate(1.6);
-  -webkit-backdrop-filter: blur(20px) saturate(1.6);
-  border: 1px solid var(--glass-border);
-}
-
-.hero-btn-glass:hover {
-  color: var(--text);
-  border-color: rgba(255,255,255,0.12);
-  background: rgba(17, 17, 22, 0.6);
-  transform: translateY(-2px);
-}
-
-.hero-btn-glass:active { transform: translateY(0); }
-
-/* ── Stats ribbon ──────────────────────────────────── */
-
-.stats-ribbon {
-  padding: 0 24px 36px;
-  max-width: 640px;
-  margin: 0 auto;
-  width: 100%;
-  position: relative;
-  z-index: 1;
-  animation: heroText 0.8s var(--ease) 0.45s both;
-}
-
-.stats-row {
+.feature-link {
   display: flex;
-  gap: 10px;
-}
-
-.stat-card {
-  flex: 1;
-  border-radius: 16px;
-  padding: 20px 18px;
-  text-align: center;
-  transition: all 0.3s var(--ease);
-}
-
-.stat-card:hover {
-  border-color: rgba(255,255,255,0.1);
-  transform: translateY(-2px);
-}
-
-.stat-value {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 1.6rem;
-  font-weight: 600;
-  color: var(--text);
-  letter-spacing: -0.02em;
-  margin-bottom: 4px;
-}
-
-.stat-label {
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: var(--sp-5) var(--sp-3);
+  background: var(--bg);
   color: var(--text-3);
-  font-weight: 500;
+  font-size: 0.75rem;
+  font-weight: 450;
+  text-decoration: none;
+  transition: background var(--duration) var(--ease), color var(--duration);
+  cursor: pointer;
 }
 
-/* ── Top clusters preview ──────────────────────────── */
+.feature-link:hover {
+  background: var(--surface);
+  color: var(--text);
+}
 
+.feature-link svg { width: 20px; height: 20px; opacity: 0.5; transition: opacity var(--duration); }
+.feature-link:hover svg { opacity: 0.9; }
+
+/* ── Top stories (landing preview) ────────────────── */
 .preview-section {
-  padding: 0 24px 80px;
-  max-width: 820px;
-  margin: 0 auto;
   width: 100%;
-  position: relative;
-  z-index: 1;
-  animation: heroText 0.8s var(--ease) 0.55s both;
+  max-width: 680px;
+  margin-top: var(--sp-6);
+  animation: slideUp 0.6s var(--ease) 0.32s both;
 }
 
 .section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: var(--sp-4);
 }
 
-.section-title {
-  font-size: 0.72rem;
+.section-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
   color: var(--text-3);
-  font-weight: 600;
 }
 
-.section-action {
-  font-size: 0.76rem;
-  color: var(--primary-light);
+.section-link {
+  font-size: 0.75rem;
+  color: var(--text-3);
   cursor: pointer;
   background: none;
   border: none;
-  font-family: inherit;
-  font-weight: 500;
-  transition: color 0.15s;
+  font-family: var(--font);
+  font-weight: 450;
+  transition: color var(--duration);
 }
+.section-link:hover { color: var(--text); }
 
-.section-action:hover { color: white; }
-
-.preview-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 10px;
-}
-
-.preview-card {
-  border-radius: 16px;
-  padding: 20px;
-  cursor: pointer;
-  transition: all 0.3s var(--ease);
-  position: relative;
+.preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
-.preview-card::before {
-  content: '';
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--primary), var(--primary-light));
-  opacity: 0;
-  transition: opacity 0.3s;
+.preview-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-5);
+  background: var(--bg);
+  cursor: pointer;
+  transition: background var(--duration) var(--ease);
 }
 
-.preview-card:hover {
-  border-color: rgba(124, 106, 239, 0.3);
-  transform: translateY(-3px);
-  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
-}
-
-.preview-card:hover::before { opacity: 1; }
+.preview-item:hover { background: var(--surface); }
 
 .preview-title {
-  font-size: 0.88rem;
-  font-weight: 500;
+  font-size: 0.875rem;
+  font-weight: 450;
   line-height: 1.4;
-  margin-bottom: 10px;
-  letter-spacing: -0.01em;
+  color: var(--text-2);
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  transition: color var(--duration);
 }
 
-.preview-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
+.preview-item:hover .preview-title { color: var(--text); }
 
-.preview-badge {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.68rem;
-  font-weight: 500;
-  color: var(--primary-light);
-  background: var(--primary-dim);
-  padding: 3px 10px;
-  border-radius: 20px;
-}
-
-.preview-date {
-  font-size: 0.7rem;
+.preview-meta {
+  font-size: 0.6875rem;
   color: var(--text-3);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
-/* ── CLUSTERS PAGE ─────────────────────────────────── */
-
+/* ── Clusters page ────────────────────────────────── */
 .page-container {
-  max-width: 900px;
+  max-width: 860px;
   margin: 0 auto;
-  padding: 72px 28px 60px;
+  padding: 80px var(--sp-5) var(--sp-8);
 }
 
 .page-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
+  margin-bottom: var(--sp-5);
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--sp-3);
 }
 
-.page-header-left h1 {
-  font-size: 1.4rem;
+.page-header h1 {
+  font-size: 1.25rem;
   font-weight: 600;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 }
 
-.page-header-left p {
-  font-size: 0.8rem;
+.page-header p {
+  font-size: 0.8125rem;
   color: var(--text-3);
   margin-top: 2px;
 }
 
 .page-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--sp-2);
   align-items: center;
 }
 
-/* Filter toggle button */
-.filter-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border-radius: 10px;
-  border: 1px solid var(--border-dim);
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  color: var(--text-3);
-  font-size: 0.8rem;
-  font-family: inherit;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.25s var(--ease);
-}
-
-.filter-toggle svg { width: 14px; height: 14px; }
-.filter-toggle:hover { color: var(--text-2); border-color: var(--border); }
-.filter-toggle.active { color: var(--primary-light); border-color: var(--primary); background: var(--primary-dim); }
-
-/* Sort dropdown */
-.sort-select {
-  padding: 8px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border-dim);
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  color: var(--text-2);
-  font-size: 0.8rem;
-  font-family: inherit;
-  font-weight: 500;
-  outline: none;
-  cursor: pointer;
-  transition: border-color 0.15s;
-}
-
-.sort-select:focus { border-color: var(--primary); }
-
-/* Collapsible filter panel */
+/* Filter panel */
 .filter-panel {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 0.4s var(--ease), opacity 0.3s ease, margin 0.4s var(--ease);
-  border-radius: 16px;
+  transition: max-height 0.35s var(--ease), opacity 0.25s, margin 0.35s var(--ease);
+  border-radius: var(--radius-lg);
   margin-bottom: 0;
 }
 
 .filter-panel.open {
-  max-height: 260px;
+  max-height: 280px;
   opacity: 1;
-  padding: 18px 20px;
-  margin-bottom: 16px;
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(1.6);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(1.6);
+  padding: var(--sp-4) var(--sp-5);
+  margin-bottom: var(--sp-4);
+  border: 1px solid var(--border);
+  background: var(--surface);
 }
 
 .filter-grid {
   display: flex;
-  gap: 8px;
+  gap: var(--sp-2);
   flex-wrap: wrap;
-  margin-bottom: 12px;
+  margin-bottom: var(--sp-3);
 }
 
 .filter-item {
@@ -490,95 +249,134 @@ body {
 }
 
 .filter-item label {
-  font-size: 0.62rem;
+  font-size: 0.625rem;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.06em;
   color: var(--text-3);
-  font-weight: 600;
+  font-weight: 500;
 }
-
-.filter-item input,
-.filter-item select {
-  padding: 8px 10px;
-  background: rgba(5, 5, 7, 0.6);
-  border: 1px solid var(--border-dim);
-  border-radius: 10px;
-  color: var(--text);
-  font-size: 0.8rem;
-  font-family: inherit;
-  outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-
-.filter-item input:focus,
-.filter-item select:focus {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px var(--primary-glow);
-}
-
-.filter-item input::placeholder { color: var(--text-3); }
 
 .filter-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--sp-2);
 }
-
-.btn {
-  padding: 9px 18px;
-  border: none;
-  border-radius: 10px;
-  font-size: 0.82rem;
-  font-family: inherit;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.25s var(--ease);
-}
-
-.btn-primary { background: var(--primary); color: white; }
-.btn-primary:hover { background: var(--primary-light); box-shadow: 0 4px 20px rgba(124,106,239,0.3); }
-.btn-primary:disabled { opacity: 0.3; cursor: not-allowed; }
-.btn-ghost { background: none; border: 1px solid var(--border-dim); color: var(--text-3); }
-.btn-ghost:hover { color: var(--text-2); border-color: var(--border); }
-.btn-sm { padding: 7px 14px; font-size: 0.78rem; }
 
 /* Active filter pills */
-.active-filters { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 14px; }
+.active-filters { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: var(--sp-4); }
 .active-filters:empty { display: none; }
 
 .filter-pill {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 5px 12px;
-  border-radius: 20px;
-  background: var(--primary-dim);
-  color: var(--primary-light);
-  font-size: 0.72rem;
-  font-weight: 500;
-  border: 1px solid rgba(124, 106, 239, 0.15);
+  padding: 4px 12px;
+  border-radius: var(--radius-full);
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-size: 0.6875rem;
+  font-weight: 450;
+  border: 1px solid var(--border);
 }
 
 .filter-pill button {
-  background: none; border: none; color: var(--primary-light);
+  background: none; border: none; color: var(--text-3);
   cursor: pointer; font-size: 0.85rem; line-height: 1; padding: 0;
-  opacity: 0.6; transition: opacity 0.15s;
+  transition: color var(--duration);
 }
-.filter-pill button:hover { opacity: 1; }
+.filter-pill button:hover { color: var(--text); }
 
-/* ── SEARCH PAGE ───────────────────────────────────── */
+/* ── Cluster cards ────────────────────────────────── */
+.cl-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-4) var(--sp-5);
+  margin-bottom: 6px;
+  cursor: pointer;
+  transition: all var(--duration) var(--ease);
+}
 
+.cl-card:hover {
+  border-color: var(--border-active);
+  background: var(--surface-2);
+}
+
+.cl-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  margin-bottom: 4px;
+}
+
+.cl-title {
+  font-size: 0.875rem;
+  font-weight: 450;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
+.cl-badge {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.cl-meta { font-size: 0.75rem; color: var(--text-3); }
+.cl-sim { font-size: 0.6875rem; color: var(--text-3); margin-bottom: 4px; font-variant-numeric: tabular-nums; }
+
+/* ── Article cards ────────────────────────────────── */
+.card-article {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-4) var(--sp-5);
+  margin-bottom: 6px;
+  transition: border-color var(--duration) var(--ease);
+}
+
+.card-article:hover { border-color: var(--border-hover); }
+
+.card-rank {
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  margin-bottom: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.card-rank .hi { color: var(--text-2); font-weight: 500; }
+
+.card-title {
+  font-size: 0.875rem;
+  font-weight: 450;
+  margin-bottom: 4px;
+  line-height: 1.45;
+}
+
+.card-title a { color: var(--text); text-decoration: none; transition: color var(--duration); }
+.card-title a:hover { color: var(--text-2); text-decoration: underline; text-underline-offset: 2px; }
+
+.card-meta {
+  display: flex;
+  gap: var(--sp-3);
+  font-size: 0.75rem;
+  color: var(--text-3);
+  margin-bottom: var(--sp-2);
+}
+
+.tags { display: flex; gap: 4px; flex-wrap: wrap; }
+
+/* ── Search ───────────────────────────────────────── */
 .search-container {
-  border-radius: 20px;
-  padding: 24px;
-  margin-bottom: 24px;
-  max-width: 680px;
-  margin-left: auto;
-  margin-right: auto;
+  max-width: 600px;
+  margin: 0 auto var(--sp-5);
 }
 
 .search-row {
   display: flex;
-  gap: 10px;
+  gap: var(--sp-2);
 }
 
 .search-input-wrap {
@@ -588,376 +386,200 @@ body {
 
 .search-input-wrap svg {
   position: absolute;
-  left: 18px;
+  left: 16px;
   top: 50%;
   transform: translateY(-50%);
   color: var(--text-3);
   pointer-events: none;
 }
 
-.search-input {
-  width: 100%;
-  padding: 16px 22px 16px 50px;
-  background: rgba(5, 5, 7, 0.5);
-  border: 1px solid var(--border-dim);
-  border-radius: 14px;
-  color: var(--text);
-  font-size: 1.05rem;
-  font-family: inherit;
-  outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.search-input:focus {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 4px var(--primary-glow);
-}
-
-.search-input::placeholder { color: var(--text-3); }
-
 .search-controls {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  margin-top: 16px;
+  gap: var(--sp-4);
+  margin-top: var(--sp-3);
   flex-wrap: wrap;
 }
 
 .weight-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-2);
   font-size: 0.75rem;
   color: var(--text-3);
-  font-weight: 500;
 }
 
-.weight-row input[type="range"] { width: 100px; accent-color: var(--primary); }
-
 .weight-val {
-  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
   color: var(--text-2);
   font-size: 0.75rem;
   min-width: 26px;
   text-align: center;
 }
 
-/* Search filter panel */
 .search-filter-panel {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 0.4s var(--ease), opacity 0.3s ease, padding 0.4s var(--ease);
-  border-radius: 16px;
-  max-width: 680px;
-  margin: 4px auto 0;
+  transition: max-height 0.35s var(--ease), opacity 0.25s, padding 0.35s var(--ease);
+  border-radius: var(--radius-lg);
+  max-width: 600px;
+  margin: var(--sp-1) auto 0;
 }
 
 .search-filter-panel.open {
   max-height: 240px;
   opacity: 1;
-  padding: 16px 18px;
-  margin-bottom: 20px;
+  padding: var(--sp-4) var(--sp-5);
+  margin-bottom: var(--sp-5);
+  border: 1px solid var(--border);
+  background: var(--surface);
 }
 
-/* ── Results ───────────────────────────────────────── */
-
-.results-wrap { max-width: 900px; margin: 0 auto; }
+/* Results */
+.results-wrap { max-width: 860px; margin: 0 auto; }
 
 .results-meta {
-  display: flex; gap: 16px; margin-bottom: 16px;
-  font-size: 0.78rem; color: var(--text-3); justify-content: center;
+  display: flex; gap: var(--sp-4); margin-bottom: var(--sp-4);
+  font-size: 0.75rem; color: var(--text-3); justify-content: center;
 }
-
-.results-meta strong {
-  font-family: 'JetBrains Mono', monospace;
-  color: var(--text-2); font-weight: 500;
-}
+.results-meta strong { color: var(--text-2); font-weight: 500; font-variant-numeric: tabular-nums; }
 
 /* Segmented control */
 .segmented {
-  display: inline-flex; gap: 2px; padding: 3px;
-  border-radius: 22px; margin-bottom: 24px;
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  margin-bottom: var(--sp-5);
 }
 
 .seg-btn {
-  padding: 9px 22px; border: none; background: none;
-  border-radius: 18px; font-size: 0.82rem; font-family: inherit;
-  font-weight: 500; color: var(--text-3); cursor: pointer;
-  transition: all 0.25s var(--ease);
+  padding: 7px 18px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-full);
+  font-size: 0.8125rem;
+  font-family: var(--font);
+  font-weight: 450;
+  color: var(--text-3);
+  cursor: pointer;
+  transition: all var(--duration) var(--ease);
 }
 
 .seg-btn:hover { color: var(--text-2); }
-.seg-btn.active { background: var(--surface-3); color: var(--text); }
+.seg-btn.active { background: var(--surface-2); color: var(--text); }
 
 .seg-count {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.7rem; margin-left: 5px; color: var(--text-3);
+  font-size: 0.6875rem;
+  margin-left: 4px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
 }
-.seg-btn.active .seg-count { color: var(--primary-light); }
+.seg-btn.active .seg-count { color: var(--text-2); }
 
-/* ── Article cards ─────────────────────────────────── */
+/* ── Card animations ──────────────────────────────── */
+.card-anim { animation: slideUp 0.3s var(--ease) both; }
 
-.card {
-  background: var(--surface);
-  border: 1px solid var(--border-dim);
-  border-radius: 14px;
-  padding: 18px 20px;
-  margin-bottom: 8px;
-  transition: all 0.2s var(--ease);
-}
-
-.card:hover { background: var(--surface-2); border-color: var(--border); }
-
-.card-rank {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.72rem; color: var(--text-3); margin-bottom: 6px;
-  display: flex; gap: 10px;
-}
-.card-rank .hi { color: var(--primary-light); font-weight: 500; }
-
-.card-title {
-  font-size: 0.95rem; font-weight: 500; margin-bottom: 6px;
-  line-height: 1.45; letter-spacing: -0.01em;
-}
-
-.card-title a { color: var(--text); text-decoration: none; transition: color 0.15s; }
-.card-title a:hover { color: var(--primary-light); }
-
-.card-meta {
-  display: flex; gap: 12px; font-size: 0.76rem;
-  color: var(--text-3); margin-bottom: 8px;
-}
-
-.tags { display: flex; gap: 5px; flex-wrap: wrap; }
-
-.tag {
-  padding: 3px 8px; font-size: 0.68rem;
-  font-weight: 500; border-radius: 6px;
-}
-
-.tag-loc { color: var(--teal); background: var(--teal-dim); }
-.tag-per { color: var(--amber); background: var(--amber-dim); }
-.tag-org { color: var(--rose); background: var(--rose-dim); }
-
-/* ── Cluster cards ─────────────────────────────────── */
-
-.cl-card {
-  background: var(--surface);
-  border: 1px solid var(--border-dim);
-  border-radius: 14px;
-  padding: 18px 20px;
-  margin-bottom: 8px;
-  cursor: pointer;
-  transition: all 0.25s var(--ease);
-}
-
-.cl-card:hover {
-  border-color: rgba(124, 106, 239, 0.4);
-  background: var(--surface-2);
-  box-shadow: 0 4px 20px rgba(0,0,0,0.2);
-  transform: translateY(-1px);
-}
-
-.cl-top {
-  display: flex; justify-content: space-between;
-  align-items: flex-start; gap: 12px; margin-bottom: 5px;
-}
-
-.cl-title {
-  font-size: 0.92rem; font-weight: 500;
-  letter-spacing: -0.01em; line-height: 1.4;
-}
-
-.cl-badge {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.7rem; font-weight: 500;
-  color: var(--primary-light); background: var(--primary-dim);
-  padding: 4px 10px; border-radius: 20px;
-  white-space: nowrap; flex-shrink: 0;
-}
-
-.cl-meta { font-size: 0.74rem; color: var(--text-3); }
-
-.cl-sim {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.7rem; color: var(--text-3); margin-bottom: 5px;
-}
-
-/* ── Card stagger animation ────────────────────────── */
-
-.card-anim { animation: cardIn 0.35s var(--ease) both; }
-
-@keyframes cardIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* ── Modal ─────────────────────────────────────────── */
-
-.overlay {
-  display: none; position: fixed; inset: 0;
-  background: rgba(5, 5, 7, 0.85);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  z-index: 200; align-items: center; justify-content: center; padding: 24px;
-}
-
-.overlay.open { display: flex; animation: fadeIn 0.2s ease; }
-
-@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-
-.modal {
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  width: 100%; max-width: 700px; max-height: 80vh;
-  overflow-y: auto; padding: 32px;
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.5);
-  animation: modalIn 0.25s var(--ease);
-}
-
-@keyframes modalIn {
-  from { opacity: 0; transform: translateY(12px) scale(0.97); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.modal::-webkit-scrollbar { width: 5px; }
-.modal::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 3px; }
-
-.modal-x {
-  float: right; width: 32px; height: 32px; border-radius: 10px;
-  border: 1px solid var(--border-dim); background: var(--surface);
-  color: var(--text-3); font-size: 1rem; cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
-  transition: all 0.15s;
-}
-
-.modal-x:hover { color: var(--text); border-color: var(--border); }
-
-.modal h2 {
-  font-size: 1.1rem; font-weight: 600; margin-bottom: 4px;
-  padding-right: 44px; letter-spacing: -0.02em;
-}
-
-.modal .cl-meta { margin-bottom: 18px; }
-
-/* ── States ────────────────────────────────────────── */
-
-.loading, .empty {
-  text-align: center; padding: 48px 20px;
-  color: var(--text-3); font-size: 0.84rem;
-}
-
-.spinner {
-  display: inline-block; width: 16px; height: 16px;
-  border: 2px solid var(--border); border-top-color: var(--primary);
-  border-radius: 50%; animation: spin 0.5s linear infinite;
-  margin-left: 8px; vertical-align: middle;
-}
-
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* ── Responsive ────────────────────────────────────── */
-
+/* ── Responsive ───────────────────────────────────── */
 @media (max-width: 768px) {
-  .hero h1 { font-size: clamp(2.2rem, 8vw, 3.5rem); }
-  .hero-buttons { flex-direction: column; gap: 10px; }
-  .hero-btn { justify-content: center; }
-  .stats-row { flex-direction: column; }
-  .preview-grid { grid-template-columns: 1fr; }
-  .page-container { padding: 64px 16px 40px; }
+  .landing-title { font-size: clamp(2.5rem, 10vw, 3.5rem); }
+  .landing-actions { flex-direction: column; }
+  .features-grid { grid-template-columns: repeat(2, 1fr); }
+  .page-container { padding: 64px var(--sp-4) var(--sp-6); }
   .page-header { flex-direction: column; align-items: flex-start; }
-  .filter-grid .filter-item { flex: 1 1 calc(50% - 4px); }
   .cl-top { flex-direction: column; gap: 4px; }
   .search-row { flex-direction: column; }
-  .search-controls { gap: 10px; }
+}
+
+@media (max-width: 480px) {
+  .features-grid { grid-template-columns: repeat(2, 1fr); }
 }
 </style>
 </head>
 <body>
 
-<!-- Back button for inner pages -->
-<button class="back-btn" id="backBtn" onclick="navTo('landing')">
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
-  GDELT Pulse
-</button>
-
 <!-- LANDING -->
 <div class="page active" id="pg-landing">
   <div class="landing">
-    <section class="hero">
-      <h1>Global News<br><span class="accent">Intelligence</span></h1>
-      <p class="hero-sub">Real-time clustering and semantic search across world events, powered by GDELT.</p>
-      <div class="hero-buttons">
-        <button class="hero-btn hero-btn-primary" onclick="navTo('clusters')">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="5" r="2"/><circle cx="5" cy="5" r="2"/><circle cx="19" cy="19" r="2"/><circle cx="5" cy="19" r="2"/><line x1="14.5" y1="9.5" x2="17.5" y2="6.5"/><line x1="9.5" y1="9.5" x2="6.5" y2="6.5"/><line x1="14.5" y1="14.5" x2="17.5" y2="17.5"/><line x1="9.5" y1="14.5" x2="6.5" y2="17.5"/></svg>
-          Explore Clusters
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="navTo('search')">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          Search Events
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="location.href='/polarization'">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M2 12h20"/><circle cx="12" cy="12" r="10"/></svg>
-          Polarization
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="location.href='/gravity'">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          Gravity Map
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="location.href='/asymmetry'">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-          Asymmetry
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="location.href='/sources'">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/><path d="M12 6v6l4 2"/></svg>
-          Source DNA
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="location.href='/propagation'">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          Propagation
-        </button>
-        <button class="hero-btn hero-btn-glass" onclick="location.href='/velocity'">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
-          Topic Velocity
-        </button>
-      </div>
-    </section>
+    <h1 class="landing-title">GDELT <span>Pulse</span></h1>
+    <p class="landing-sub">Real-time clustering and semantic search across world events.</p>
+    <div class="landing-actions">
+      <button class="btn btn-primary btn-lg" onclick="navTo('clusters')">Explore Clusters</button>
+      <button class="btn btn-lg" onclick="navTo('search')">Search Events</button>
+    </div>
 
-    <section class="stats-ribbon">
-      <div class="stats-row">
-        <div class="stat-card glass"><div class="stat-value" data-counter="total_articles">--</div><div class="stat-label">Articles</div></div>
-        <div class="stat-card glass"><div class="stat-value" data-counter="embedded_articles">--</div><div class="stat-label">Embedded</div></div>
-        <div class="stat-card glass"><div class="stat-value" data-counter="total_clusters">--</div><div class="stat-label">Clusters</div></div>
+    <div class="features">
+      <div class="features-grid">
+        <a class="feature-link" href="/globe">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          Globe
+        </a>
+        <a class="feature-link" href="/polarization">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 2v20M2 12h20"/><circle cx="12" cy="12" r="10"/></svg>
+          Polarization
+        </a>
+        <a class="feature-link" href="/gravity">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="5" r="2"/><circle cx="5" cy="5" r="2"/><circle cx="19" cy="19" r="2"/><circle cx="5" cy="19" r="2"/><line x1="14.5" y1="9.5" x2="17.5" y2="6.5"/><line x1="9.5" y1="9.5" x2="6.5" y2="6.5"/><line x1="14.5" y1="14.5" x2="17.5" y2="17.5"/><line x1="9.5" y1="14.5" x2="6.5" y2="17.5"/></svg>
+          Gravity
+        </a>
+        <a class="feature-link" href="/asymmetry">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+          Asymmetry
+        </a>
+        <a class="feature-link" href="/sources">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 7V4a2 2 0 0 1 2-2h8.5L20 7.5V20a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3"/><polyline points="14 2 14 8 20 8"/><line x1="2" y1="15" x2="12" y2="15"/><polyline points="9 12 12 15 9 18"/></svg>
+          Sources
+        </a>
+        <a class="feature-link" href="/propagation">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          Propagation
+        </a>
+        <a class="feature-link" href="/velocity">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+          Velocity
+        </a>
+        <a class="feature-link" onclick="navTo('clusters')" style="cursor:pointer">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Search
+        </a>
       </div>
-    </section>
+    </div>
 
     <section class="preview-section">
       <div class="section-header">
-        <span class="section-title">Top Clusters</span>
-        <button class="section-action" onclick="navTo('clusters')">View all &rarr;</button>
+        <span class="section-label">Trending stories</span>
+        <button class="section-link" onclick="navTo('clusters')">View all &rarr;</button>
       </div>
-      <div class="preview-grid" id="previewClusters"><div class="loading">Loading<span class="spinner"></span></div></div>
+      <div id="previewClusters" class="preview-list">
+        <div class="loading">Loading<span class="spinner"></span></div>
+      </div>
     </section>
   </div>
 </div>
 
 <!-- CLUSTERS -->
 <div class="page" id="pg-clusters">
+  <div class="topbar">
+    <a class="topbar-back" onclick="navTo('landing')">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+      GDELT Pulse
+    </a>
+  </div>
   <div class="page-container">
     <div class="page-header">
-      <div class="page-header-left">
+      <div>
         <h1>Event Clusters</h1>
         <p id="clusterCount">Groups of related articles about the same event</p>
       </div>
       <div class="page-actions">
-        <button class="filter-toggle" id="cfToggle">
+        <button class="btn btn-sm" id="cfToggle">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="11" y1="18" x2="13" y2="18"/></svg>
           Filters
         </button>
-        <select class="sort-select" id="cfSort">
+        <select class="select" id="cfSort">
           <option value="articles">Most articles</option>
           <option value="recent">Most recent</option>
           <option value="oldest">Oldest first</option>
@@ -967,18 +589,18 @@ body {
 
     <div class="filter-panel" id="cfPanel">
       <div class="filter-grid">
-        <div class="filter-item"><label>Location</label><input type="text" id="cfLoc" placeholder="e.g. Turkey"></div>
-        <div class="filter-item"><label>Person</label><input type="text" id="cfPer" placeholder="e.g. Biden"></div>
-        <div class="filter-item"><label>Organization</label><input type="text" id="cfOrg" placeholder="e.g. NATO"></div>
-        <div class="filter-item"><label>Theme</label><input type="text" id="cfThm" placeholder="e.g. ARMEDCONFLICT"></div>
-        <div class="filter-item"><label>Domain</label><input type="text" id="cfDom" placeholder="e.g. bbc.co.uk"></div>
-        <div class="filter-item"><label>Source</label><input type="text" id="cfSrc" placeholder="e.g. reuters"></div>
-        <div class="filter-item"><label>Date from</label><input type="date" id="cfDF"></div>
-        <div class="filter-item"><label>Date to</label><input type="date" id="cfDT"></div>
+        <div class="filter-item"><label>Location</label><input class="input" type="text" id="cfLoc" placeholder="e.g. Turkey"></div>
+        <div class="filter-item"><label>Person</label><input class="input" type="text" id="cfPer" placeholder="e.g. Biden"></div>
+        <div class="filter-item"><label>Organization</label><input class="input" type="text" id="cfOrg" placeholder="e.g. NATO"></div>
+        <div class="filter-item"><label>Theme</label><input class="input" type="text" id="cfThm" placeholder="e.g. ARMEDCONFLICT"></div>
+        <div class="filter-item"><label>Domain</label><input class="input" type="text" id="cfDom" placeholder="e.g. bbc.co.uk"></div>
+        <div class="filter-item"><label>Source</label><input class="input" type="text" id="cfSrc" placeholder="e.g. reuters"></div>
+        <div class="filter-item"><label>Date from</label><input class="input" type="date" id="cfDF"></div>
+        <div class="filter-item"><label>Date to</label><input class="input" type="date" id="cfDT"></div>
       </div>
       <div class="filter-actions">
-        <button class="btn btn-primary btn-sm" id="cfApply">Apply filters</button>
-        <button class="btn btn-ghost btn-sm" id="cfClear">Clear</button>
+        <button class="btn btn-primary btn-sm" id="cfApply">Apply</button>
+        <button class="btn btn-sm" id="cfClear">Clear</button>
       </div>
     </div>
 
@@ -989,19 +611,25 @@ body {
 
 <!-- SEARCH -->
 <div class="page" id="pg-search">
+  <div class="topbar">
+    <a class="topbar-back" onclick="navTo('landing')">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+      GDELT Pulse
+    </a>
+  </div>
   <div class="page-container">
-    <div style="text-align:center; margin-bottom: 12px">
-      <h1 class="page-header-left" style="font-size:1.4rem;font-weight:600;letter-spacing:-0.03em">Search</h1>
-      <p style="font-size:0.82rem;color:var(--text-3);margin-top:4px">Hybrid semantic + keyword search across events</p>
+    <div style="text-align:center; margin-bottom: var(--sp-4)">
+      <h1 style="font-size:1.25rem;font-weight:600;letter-spacing:-0.02em">Search</h1>
+      <p style="font-size:0.8125rem;color:var(--text-3);margin-top:2px">Hybrid semantic + keyword search across events</p>
     </div>
 
-    <div class="search-container glass">
+    <div class="search-container">
       <div class="search-row">
         <div class="search-input-wrap">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <input class="search-input" type="text" id="searchInput" placeholder="Search articles and events..." autocomplete="off">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input class="input input-lg" type="text" id="searchInput" placeholder="Search articles and events..." autocomplete="off" style="padding-left:44px">
         </div>
-        <button class="btn btn-primary" style="padding:16px 24px;font-size:0.9rem;border-radius:14px" id="searchBtn">Search</button>
+        <button class="btn btn-primary" style="padding:14px 24px;border-radius:var(--radius-lg)" id="searchBtn">Search</button>
       </div>
 
       <div class="search-controls">
@@ -1011,23 +639,23 @@ body {
           <span class="weight-val" id="wVal">0.5</span>
           <span>Keyword</span>
         </div>
-        <button class="filter-toggle" id="searchFilterToggle">
+        <button class="btn btn-sm" id="searchFilterToggle">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="11" y1="18" x2="13" y2="18"/></svg>
           Filters
         </button>
       </div>
     </div>
 
-    <div class="search-filter-panel glass" id="searchFilterPanel">
+    <div class="search-filter-panel" id="searchFilterPanel">
       <div class="filter-grid" style="margin-bottom:0">
-        <div class="filter-item"><label>Location</label><input type="text" id="sfLoc" placeholder="e.g. Turkey"></div>
-        <div class="filter-item"><label>Person</label><input type="text" id="sfPer" placeholder="e.g. Biden"></div>
-        <div class="filter-item"><label>Organization</label><input type="text" id="sfOrg" placeholder="e.g. NATO"></div>
-        <div class="filter-item"><label>Theme</label><input type="text" id="sfThm" placeholder="e.g. ECON"></div>
-        <div class="filter-item"><label>Domain</label><input type="text" id="sfDom" placeholder="e.g. bbc.co.uk"></div>
-        <div class="filter-item"><label>Source</label><input type="text" id="sfSrc" placeholder="e.g. reuters"></div>
-        <div class="filter-item"><label>Date from</label><input type="date" id="sfDF"></div>
-        <div class="filter-item"><label>Date to</label><input type="date" id="sfDT"></div>
+        <div class="filter-item"><label>Location</label><input class="input" type="text" id="sfLoc" placeholder="e.g. Turkey"></div>
+        <div class="filter-item"><label>Person</label><input class="input" type="text" id="sfPer" placeholder="e.g. Biden"></div>
+        <div class="filter-item"><label>Organization</label><input class="input" type="text" id="sfOrg" placeholder="e.g. NATO"></div>
+        <div class="filter-item"><label>Theme</label><input class="input" type="text" id="sfThm" placeholder="e.g. ECON"></div>
+        <div class="filter-item"><label>Domain</label><input class="input" type="text" id="sfDom" placeholder="e.g. bbc.co.uk"></div>
+        <div class="filter-item"><label>Source</label><input class="input" type="text" id="sfSrc" placeholder="e.g. reuters"></div>
+        <div class="filter-item"><label>Date from</label><input class="input" type="date" id="sfDF"></div>
+        <div class="filter-item"><label>Date to</label><input class="input" type="date" id="sfDT"></div>
       </div>
     </div>
 
@@ -1035,7 +663,7 @@ body {
       <div class="results-wrap">
         <div class="results-meta" id="searchMeta"></div>
         <div style="text-align:center">
-          <div class="segmented glass">
+          <div class="segmented">
             <button class="seg-btn active" data-stab="s-arts">Articles<span class="seg-count" id="sArtCnt"></span></button>
             <button class="seg-btn" data-stab="s-cls">Clusters<span class="seg-count" id="sClCnt"></span></button>
           </div>
@@ -1050,9 +678,9 @@ body {
 <!-- Modal -->
 <div class="overlay" id="overlay">
   <div class="modal">
-    <button class="modal-x" id="modalX">&times;</button>
-    <h2 id="mTitle"></h2>
-    <div class="cl-meta" id="mMeta"></div>
+    <button class="modal-close" id="modalX">&times;</button>
+    <h2 id="mTitle" style="font-size:1.1rem;font-weight:600;margin-bottom:4px;padding-right:44px;letter-spacing:-0.02em"></h2>
+    <div class="cl-meta" id="mMeta" style="margin-bottom:var(--sp-4);font-size:0.75rem;color:var(--text-3)"></div>
     <div id="mBody"></div>
   </div>
 </div>
@@ -1064,7 +692,6 @@ const $=s=>document.querySelector(s), $$=s=>document.querySelectorAll(s), API='/
 function navTo(page) {
   $$('.page').forEach(p => p.classList.remove('active'));
   $(`#pg-${page}`).classList.add('active');
-  $('#backBtn').classList.toggle('visible', page !== 'landing');
   if (page === 'landing') loadLanding();
   if (page === 'clusters') loadClustersPage();
   if (page === 'search') setTimeout(() => $('#searchInput').focus(), 100);
@@ -1074,36 +701,19 @@ function navTo(page) {
 const initPage = location.hash.replace('#', '') || 'landing';
 if (initPage !== 'landing') navTo(initPage);
 
-// ── Animated counter ────────────────────────────────────
-function animateValue(el, target, duration = 700) {
-  if (!target && target !== 0) { el.textContent = '--'; return; }
-  const start = performance.now();
-  const update = (now) => {
-    const progress = Math.min((now - start) / duration, 1);
-    const eased = 1 - Math.pow(1 - progress, 3);
-    el.textContent = Math.floor(eased * target).toLocaleString();
-    if (progress < 1) requestAnimationFrame(update);
-  };
-  requestAnimationFrame(update);
-}
-
 // ── Landing page ────────────────────────────────────────
 let _landingLoaded = false;
 async function loadLanding() {
   if (_landingLoaded) return;
   try {
-    const [stats, clusters] = await Promise.all([
-      fetch(`${API}/stats`).then(r => r.json()),
-      fetch(`${API}/clusters?limit=6&sort=articles`).then(r => r.json()),
-    ]);
+    const clusters = await fetch(`${API}/clusters?limit=6&sort=articles`).then(r => r.json());
     _landingLoaded = true;
 
-    $$('[data-counter]').forEach(el => animateValue(el, stats[el.dataset.counter]));
-
-    $('#previewClusters').innerHTML = clusters.length
-      ? clusters.map((c, i) => mkPreviewCard(c, i)).join('')
-      : '<div class="empty">No clusters yet &mdash; the pipeline is collecting data.</div>';
-    $$('#previewClusters .preview-card').forEach(el =>
+    const el = $('#previewClusters');
+    el.innerHTML = clusters.length
+      ? clusters.map((c, i) => mkPreviewItem(c, i)).join('')
+      : '<div class="empty">No clusters yet</div>';
+    el.querySelectorAll('.preview-item').forEach(el =>
       el.addEventListener('click', () => openCluster(el.dataset.id))
     );
   } catch (e) {
@@ -1112,14 +722,10 @@ async function loadLanding() {
 }
 loadLanding();
 
-function mkPreviewCard(c, idx) {
-  const delay = `style="animation-delay:${idx * 60}ms"`;
-  return `<div class="preview-card glass card-anim" data-id="${c.id}" ${delay}>
-    <div class="preview-title">${esc(c.representative_title || '(untitled)')}</div>
-    <div class="preview-footer">
-      <span class="preview-badge">${c.article_count} articles</span>
-      <span class="preview-date">${fmtDate(c.last_article_at)}</span>
-    </div>
+function mkPreviewItem(c, idx) {
+  return `<div class="preview-item" data-id="${c.id}" style="animation: slideUp 0.3s var(--ease) ${idx * 50}ms both">
+    <span class="preview-title">${esc(c.representative_title || '(untitled)')}</span>
+    <span class="preview-meta">${fmtDate(c.last_article_at)}</span>
   </div>`;
 }
 
@@ -1261,10 +867,10 @@ function mkCard(a, rank, scored, idx) {
   if (scored) {
     const sm = scored.semantic_rank ? `sem #${scored.semantic_rank}` : 'sem -';
     const kw = scored.keyword_rank ? `kw #${scored.keyword_rank}` : 'kw -';
-    rk = `<div class="card-rank"><span class="hi">#${rank} &middot; ${scored.rrf_score.toFixed(5)}</span><span>${sm}</span><span>${kw}</span></div>`;
+    rk = `<div class="card-rank"><span class="hi">#${rank} &middot; ${scored.rrf_score.toFixed(5)}</span> <span>${sm}</span> <span>${kw}</span></div>`;
   }
   let tg = tags(a.locations, 'loc', r => r.name || r) + tags(a.persons, 'per', r => r) + tags(a.organizations, 'org', r => r);
-  return `<div class="card card-anim" ${delay}>${rk}<div class="card-title"><a href="${esc(url)}" target="_blank" rel="noopener noreferrer">${title}</a></div><div class="card-meta"><span>${esc(a.domain || '')}</span><span>${fmtDate(a.gdelt_timestamp)}</span></div>${tg ? `<div class="tags">${tg}</div>` : ''}</div>`;
+  return `<div class="card-article card-anim" ${delay}>${rk}<div class="card-title"><a href="${esc(url)}" target="_blank" rel="noopener noreferrer">${title}</a></div><div class="card-meta"><span>${esc(a.domain || '')}</span><span>${fmtDate(a.gdelt_timestamp)}</span></div>${tg ? `<div class="tags">${tg}</div>` : ''}</div>`;
 }
 
 function mkClCard(c, idx) {

--- a/src/gdelt_event_pipeline/api/static/polarization.html
+++ b/src/gdelt_event_pipeline/api/static/polarization.html
@@ -6,442 +6,347 @@
 <title>Narrative Polarization | GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
-
-:root {
-  --bg: #050507;
-  --bg-raised: #0c0c10;
-  --surface: #111116;
-  --surface-2: #17171d;
-  --surface-3: #1d1d25;
-  --border: #222230;
-  --border-dim: #1a1a24;
-  --text: #ededf0;
-  --text-2: #b0b0be;
-  --text-3: #6e6e82;
-  --primary: #7c6aef;
-  --primary-light: #9d8ff5;
-  --primary-dim: rgba(124, 106, 239, 0.1);
-  --primary-glow: rgba(124, 106, 239, 0.06);
-  --teal: #2dd4a8;
-  --teal-dim: rgba(45, 212, 168, 0.1);
-  --amber: #e5a63e;
-  --amber-dim: rgba(229, 166, 62, 0.1);
-  --rose: #e5637a;
-  --rose-dim: rgba(229, 99, 122, 0.1);
-  --negative: #e5637a;
-  --positive: #2dd4a8;
-  --glass-bg: rgba(17, 17, 22, 0.4);
-  --glass-border: rgba(255, 255, 255, 0.06);
-  --glass-blur: 20px;
-  --ease: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-body {
-  font-family: 'DM Sans', -apple-system, sans-serif;
-  background: var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  line-height: 1.55;
-  -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
-}
-
-::selection { background: var(--primary-dim); color: var(--primary-light); }
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 3px; }
-
-/* ── Top bar ──────────────────────────────────────── */
-
-.topbar {
-  position: fixed; top: 0; left: 0; right: 0;
-  z-index: 100;
-  display: flex; align-items: center; gap: 16px;
-  padding: 14px 24px;
-  background: rgba(5, 5, 7, 0.8);
-  backdrop-filter: blur(20px) saturate(1.6);
-  -webkit-backdrop-filter: blur(20px) saturate(1.6);
-  border-bottom: 1px solid var(--glass-border);
-}
-
-.topbar-back {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 6px 14px; border-radius: 20px;
-  border: 1px solid var(--border-dim); background: none;
-  color: var(--text-2); font-size: 0.78rem; font-family: inherit;
-  font-weight: 500; cursor: pointer; text-decoration: none;
-  transition: all 0.2s var(--ease);
-}
-.topbar-back:hover { color: var(--text); border-color: var(--border); }
-.topbar-back svg { width: 14px; height: 14px; }
-
-.topbar-title {
-  font-size: 0.9rem; font-weight: 600; letter-spacing: -0.02em;
-}
-.topbar-title .accent { color: var(--primary-light); }
-
-/* ── Page layout ──────────────────────────────────── */
+/* ── Page-specific styles (polarization) ─────────── */
 
 .page-wrap {
-  max-width: 1000px; margin: 0 auto;
-  padding: 80px 24px 60px;
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 var(--sp-5);
 }
-
-.page-intro {
-  text-align: center; margin-bottom: 40px;
-  animation: fadeUp 0.6s var(--ease) both;
-}
-
-.page-intro h1 {
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  font-weight: 700; letter-spacing: -0.04em;
-  margin-bottom: 10px;
-}
-
-.page-intro h1 .accent {
-  background: linear-gradient(135deg, var(--negative), var(--primary-light), var(--positive));
-  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.page-intro p {
-  font-size: 0.92rem; color: var(--text-3);
-  max-width: 540px; margin: 0 auto;
-}
-
-@keyframes fadeUp {
-  from { opacity: 0; transform: translateY(18px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* ── Overview stats ───────────────────────────────── */
-
-.overview-stats {
-  display: flex; gap: 10px; margin-bottom: 32px;
-  animation: fadeUp 0.6s var(--ease) 0.1s both;
-}
-
-.ov-stat {
-  flex: 1; text-align: center; padding: 18px 14px;
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur));
-  border: 1px solid var(--glass-border);
-  border-radius: 14px;
-}
-
-.ov-stat-val {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 1.4rem; font-weight: 600; margin-bottom: 2px;
-}
-
-.ov-stat-label {
-  font-size: 0.66rem; text-transform: uppercase;
-  letter-spacing: 0.07em; color: var(--text-3); font-weight: 500;
-}
-
-/* ── Overview chart ───────────────────────────────── */
-
-.overview-chart-wrap {
-  background: var(--surface); border: 1px solid var(--border-dim);
-  border-radius: 16px; padding: 24px; margin-bottom: 36px;
-  animation: fadeUp 0.6s var(--ease) 0.15s both;
-}
-
-.overview-chart-wrap h3 {
-  font-size: 0.78rem; text-transform: uppercase;
-  letter-spacing: 0.07em; color: var(--text-3);
-  font-weight: 600; margin-bottom: 16px;
-}
-
-.chart-container { position: relative; height: 220px; }
 
 /* ── Polarization cards ───────────────────────────── */
 
-.section-label {
-  font-size: 0.72rem; text-transform: uppercase;
-  letter-spacing: 0.08em; color: var(--text-3);
-  font-weight: 600; margin-bottom: 14px;
-  animation: fadeUp 0.6s var(--ease) 0.2s both;
-}
-
 .pol-card {
-  background: var(--surface); border: 1px solid var(--border-dim);
-  border-radius: 16px; padding: 22px 24px; margin-bottom: 10px;
-  cursor: pointer; transition: all 0.25s var(--ease);
-  animation: fadeUp 0.4s var(--ease) both;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+  margin-bottom: var(--sp-3);
+  cursor: pointer;
+  transition: border-color var(--duration) var(--ease), background var(--duration) var(--ease);
 }
 
 .pol-card:hover {
-  border-color: rgba(124, 106, 239, 0.4);
+  border-color: var(--border-active);
   background: var(--surface-2);
-  box-shadow: 0 4px 24px rgba(0,0,0,0.25);
-  transform: translateY(-2px);
 }
 
 .pol-card-top {
-  display: flex; justify-content: space-between;
-  align-items: flex-start; gap: 16px; margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-3);
 }
 
 .pol-card-title {
-  font-size: 0.94rem; font-weight: 500; line-height: 1.4;
-  letter-spacing: -0.01em; flex: 1;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+  flex: 1;
+  color: var(--text);
 }
 
 .pol-score {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.82rem; font-weight: 600;
-  padding: 5px 12px; border-radius: 20px;
-  white-space: nowrap; flex-shrink: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  flex-shrink: 0;
 }
 
-.pol-score-high { color: var(--negative); background: var(--rose-dim); }
-.pol-score-med { color: var(--amber); background: var(--amber-dim); }
-.pol-score-low { color: var(--teal); background: var(--teal-dim); }
+.pol-score-high { color: var(--negative); }
+.pol-score-med  { color: var(--warning); }
+.pol-score-low  { color: var(--positive); }
 
 .pol-card-meta {
-  display: flex; gap: 16px; font-size: 0.76rem;
-  color: var(--text-3); margin-bottom: 12px;
+  display: flex;
+  gap: var(--sp-4);
+  font-size: 0.75rem;
+  color: var(--text-3);
+  margin-bottom: var(--sp-3);
 }
 
 .pol-card-meta .mono {
-  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-2);
 }
 
 /* ── Tone bar ─────────────────────────────────────── */
 
 .tone-bar-wrap {
-  display: flex; align-items: center; gap: 8px;
-  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-2);
 }
 
 .tone-bar-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.66rem; color: var(--text-3);
-  min-width: 34px; text-align: right;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+  min-width: 34px;
+  text-align: right;
 }
 
 .tone-bar-label.pos { color: var(--positive); }
 .tone-bar-label.neg { color: var(--negative); }
 
 .tone-bar-track {
-  flex: 1; height: 6px; background: var(--surface-3);
-  border-radius: 3px; position: relative; overflow: hidden;
+  flex: 1;
+  height: 4px;
+  background: var(--surface-3);
+  border-radius: 2px;
+  position: relative;
+  overflow: hidden;
 }
 
 .tone-bar-fill {
-  position: absolute; top: 0; height: 100%; border-radius: 3px;
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
 }
 
 .tone-bar-avg {
-  position: absolute; top: -3px; width: 3px; height: 12px;
-  background: var(--text); border-radius: 1px;
+  position: absolute;
+  top: -4px;
+  width: 2px;
+  height: 12px;
+  background: var(--text);
+  border-radius: 1px;
   transform: translateX(-50%);
 }
 
 /* ── Source mini-bars ──────────────────────────────── */
 
-.source-bars { margin-top: 6px; }
+.source-bars { margin-top: var(--sp-2); }
 
 .src-row {
-  display: flex; align-items: center; gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
   margin-bottom: 3px;
 }
 
 .src-name {
-  font-size: 0.7rem; color: var(--text-3);
-  min-width: 110px; max-width: 110px;
-  white-space: nowrap; overflow: hidden;
-  text-overflow: ellipsis; text-align: right;
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  min-width: 110px;
+  max-width: 110px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
 }
 
 .src-bar-track {
-  flex: 1; height: 4px; background: var(--surface-3);
-  border-radius: 2px; position: relative;
+  flex: 1;
+  height: 3px;
+  background: var(--surface-3);
+  border-radius: 2px;
+  position: relative;
 }
 
 .src-bar-fill {
-  position: absolute; top: 0; height: 100%; border-radius: 2px;
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
 }
 
 .src-tone {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.64rem; min-width: 36px;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  min-width: 36px;
 }
 
 .src-tone.pos { color: var(--positive); }
 .src-tone.neg { color: var(--negative); }
 
-/* ── Detail modal ─────────────────────────────────── */
-
-.overlay {
-  display: none; position: fixed; inset: 0;
-  background: rgba(5, 5, 7, 0.88);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  z-index: 200; align-items: flex-start;
-  justify-content: center; padding: 24px;
-  overflow-y: auto;
-}
-
-.overlay.open { display: flex; animation: fadeIn 0.2s ease; }
-
-@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+/* ── Detail modal overrides ──────────────────────── */
 
 .detail-panel {
-  background: var(--bg-raised);
+  background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: 20px;
-  width: 100%; max-width: 820px;
-  padding: 32px; margin: 40px 0;
-  box-shadow: 0 12px 48px rgba(0,0,0,0.5);
-  animation: modalIn 0.25s var(--ease);
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 820px;
+  padding: var(--sp-6);
+  margin: var(--sp-7) 0;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: modalIn 0.2s var(--ease);
 }
-
-@keyframes modalIn {
-  from { opacity: 0; transform: translateY(12px) scale(0.97); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.detail-panel::-webkit-scrollbar { width: 5px; }
-.detail-panel::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 3px; }
-
-.detail-close {
-  float: right; width: 32px; height: 32px; border-radius: 10px;
-  border: 1px solid var(--border-dim); background: var(--surface);
-  color: var(--text-3); font-size: 1rem; cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
-  transition: all 0.15s;
-}
-.detail-close:hover { color: var(--text); border-color: var(--border); }
 
 .detail-title {
-  font-size: 1.15rem; font-weight: 600; margin-bottom: 6px;
-  padding-right: 44px; letter-spacing: -0.02em;
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: var(--sp-2);
+  padding-right: 44px;
+  letter-spacing: -0.02em;
+  color: var(--text);
 }
 
 .detail-meta {
-  font-size: 0.78rem; color: var(--text-3); margin-bottom: 20px;
+  font-size: 0.8125rem;
+  color: var(--text-3);
+  margin-bottom: var(--sp-5);
 }
 
 .detail-stats {
-  display: flex; gap: 10px; margin-bottom: 24px;
+  display: flex;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-5);
 }
 
 .detail-stat {
-  flex: 1; text-align: center; padding: 14px 10px;
-  background: var(--surface); border: 1px solid var(--border-dim);
-  border-radius: 12px;
+  flex: 1;
+  text-align: center;
+  padding: var(--sp-4) var(--sp-3);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 .detail-stat-val {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 1.1rem; font-weight: 600; margin-bottom: 2px;
+  font-size: 1.125rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  margin-bottom: 2px;
 }
 
 .detail-stat-label {
-  font-size: 0.62rem; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--text-3); font-weight: 500;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
 }
 
 .detail-section {
-  margin-bottom: 24px;
+  margin-bottom: var(--sp-5);
 }
 
 .detail-section h3 {
-  font-size: 0.72rem; text-transform: uppercase;
-  letter-spacing: 0.07em; color: var(--text-3);
-  font-weight: 600; margin-bottom: 12px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+  margin-bottom: var(--sp-3);
 }
 
-.detail-chart { position: relative; height: 200px; margin-bottom: 8px; }
+.detail-chart {
+  position: relative;
+  height: 200px;
+  margin-bottom: var(--sp-2);
+}
 
 /* ── Source groups in detail ──────────────────────── */
 
 .source-group {
-  margin-bottom: 16px; padding: 16px;
-  background: var(--surface); border: 1px solid var(--border-dim);
-  border-radius: 12px;
+  margin-bottom: var(--sp-3);
+  padding: var(--sp-4);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 .source-group-header {
-  display: flex; justify-content: space-between;
-  align-items: center; margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--sp-3);
   cursor: pointer;
 }
 
 .source-group-name {
-  font-size: 0.86rem; font-weight: 500;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text);
 }
 
 .source-group-meta {
-  display: flex; gap: 12px; align-items: center;
+  display: flex;
+  gap: var(--sp-3);
+  align-items: center;
 }
 
 .source-group-tone {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.8rem; font-weight: 600;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .source-group-count {
-  font-size: 0.72rem; color: var(--text-3);
-  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
 }
 
-.source-articles { margin-top: 8px; }
+.source-articles { margin-top: var(--sp-2); }
 
 .source-article {
-  padding: 8px 0;
-  border-top: 1px solid var(--border-dim);
-  display: flex; justify-content: space-between;
-  align-items: flex-start; gap: 12px;
+  padding: var(--sp-2) 0;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--sp-3);
 }
 
-.source-article:first-child { border-top: none; padding-top: 0; }
+.source-article:first-child {
+  border-top: none;
+  padding-top: 0;
+}
 
 .source-article-title {
-  font-size: 0.82rem; flex: 1;
+  font-size: 0.8125rem;
+  flex: 1;
 }
 
 .source-article-title a {
-  color: var(--text-2); text-decoration: none;
-  transition: color 0.15s;
+  color: var(--text-2);
+  text-decoration: none;
+  transition: color var(--duration);
 }
-.source-article-title a:hover { color: var(--primary-light); }
+
+.source-article-title a:hover {
+  color: var(--accent-text);
+}
 
 .source-article-tone {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.74rem; white-space: nowrap;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
-/* ── Loading / empty states ───────────────────────── */
+.source-article-tone.pos { color: var(--positive); }
+.source-article-tone.neg { color: var(--negative); }
 
-.loading, .empty-state {
-  text-align: center; padding: 48px 20px;
-  color: var(--text-3); font-size: 0.86rem;
+/* ── Section label ───────────────────────────────── */
+
+.section-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+  margin-bottom: var(--sp-4);
 }
 
-.spinner {
-  display: inline-block; width: 16px; height: 16px;
-  border: 2px solid var(--border); border-top-color: var(--primary);
-  border-radius: 50%; animation: spin 0.5s linear infinite;
-  margin-left: 8px; vertical-align: middle;
-}
-
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* ── Responsive ───────────────────────────────────── */
+/* ── Responsive overrides ────────────────────────── */
 
 @media (max-width: 768px) {
-  .page-wrap { padding: 72px 14px 40px; }
-  .overview-stats { flex-direction: column; }
   .detail-stats { flex-wrap: wrap; }
-  .detail-stat { flex: 1 1 calc(50% - 5px); }
-  .pol-card-top { flex-direction: column; gap: 6px; }
+  .detail-stat { flex: 1 1 calc(50% - 6px); }
+  .pol-card-top { flex-direction: column; gap: var(--sp-2); }
   .src-name { min-width: 80px; max-width: 80px; }
 }
 </style>
@@ -449,44 +354,43 @@ body {
 <body>
 
 <!-- Top bar -->
-<div class="topbar">
-  <a href="/" class="topbar-back">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
     GDELT Pulse
   </a>
-  <span class="topbar-title">Narrative <span class="accent">Polarization</span></span>
-</div>
+</nav>
 
 <!-- Page content -->
 <div class="page-wrap">
   <div class="page-intro">
-    <h1>Narrative <span class="accent">Polarization</span></h1>
-    <p>Stories where the world disagrees on what happened. High polarization = same event, opposite framing across sources.</p>
+    <h1>Narrative Polarization</h1>
+    <p>Stories where the world disagrees on what happened. High polarization means the same event, opposite framing across sources.</p>
   </div>
 
   <!-- Overview stats -->
-  <div class="overview-stats">
-    <div class="ov-stat"><div class="ov-stat-val" id="statStories">--</div><div class="ov-stat-label">Polarized Stories</div></div>
-    <div class="ov-stat"><div class="ov-stat-val" id="statAvgScore">--</div><div class="ov-stat-label">Avg Polarization</div></div>
-    <div class="ov-stat"><div class="ov-stat-val" id="statMaxScore">--</div><div class="ov-stat-label">Max Polarization</div></div>
-    <div class="ov-stat"><div class="ov-stat-val" id="statSources">--</div><div class="ov-stat-label">Avg Sources/Story</div></div>
+  <div class="stat-grid stat-grid-4 animate-in" style="margin-bottom: var(--sp-6);">
+    <div class="stat-card"><div class="stat-value" id="statStories">--</div><div class="stat-label">Polarized Stories</div></div>
+    <div class="stat-card"><div class="stat-value" id="statAvgScore">--</div><div class="stat-label">Avg Polarization</div></div>
+    <div class="stat-card"><div class="stat-value" id="statMaxScore">--</div><div class="stat-label">Max Polarization</div></div>
+    <div class="stat-card"><div class="stat-value" id="statSources">--</div><div class="stat-label">Avg Sources / Story</div></div>
   </div>
 
-  <!-- Overview scatter chart: polarization vs article count -->
-  <div class="overview-chart-wrap">
+  <!-- Overview scatter chart -->
+  <div class="card chart-section animate-in" style="margin-bottom: var(--sp-6);">
     <h3>Polarization Score Distribution</h3>
     <div class="chart-container"><canvas id="overviewChart"></canvas></div>
   </div>
 
   <!-- Story list -->
   <div class="section-label">Most Polarized Stories</div>
-  <div id="storyList"><div class="loading">Analyzing narrative polarization<span class="spinner"></span></div></div>
+  <div id="storyList"><div class="loading"><span class="spinner"></span> Analyzing narrative polarization</div></div>
 </div>
 
 <!-- Detail overlay -->
 <div class="overlay" id="overlay">
   <div class="detail-panel" id="detailPanel">
-    <button class="detail-close" id="detailClose">&times;</button>
+    <button class="modal-close" id="detailClose">&times;</button>
     <h2 class="detail-title" id="detailTitle"></h2>
     <div class="detail-meta" id="detailMeta"></div>
     <div class="detail-stats" id="detailStats"></div>
@@ -511,9 +415,9 @@ const $ = s => document.querySelector(s);
 const $$ = s => document.querySelectorAll(s);
 
 // Chart.js global config
-Chart.defaults.color = '#6e6e82';
-Chart.defaults.borderColor = 'rgba(34,34,48,0.6)';
-Chart.defaults.font.family = "'DM Sans', sans-serif";
+Chart.defaults.color = '#63636e';
+Chart.defaults.borderColor = 'rgba(255,255,255,0.06)';
+Chart.defaults.font.family = "'Inter', sans-serif";
 
 let _data = [];
 let _overviewChart = null;
@@ -535,9 +439,9 @@ function toneColor(t) {
 }
 
 function toneColorRgba(t, alpha) {
-  if (t < -1) return `rgba(229, 99, 122, ${alpha})`;
-  if (t > 1) return `rgba(45, 212, 168, ${alpha})`;
-  return `rgba(110, 110, 130, ${alpha})`;
+  if (t < -1) return `rgba(248, 113, 113, ${alpha})`;
+  if (t > 1) return `rgba(52, 211, 153, ${alpha})`;
+  return `rgba(99, 99, 110, ${alpha})`;
 }
 
 function scoreClass(s) {
@@ -558,7 +462,7 @@ async function loadData() {
     renderOverview(data);
     renderStories(data);
   } catch (e) {
-    $('#storyList').innerHTML = `<div class="empty-state">${esc(e.message)}</div>`;
+    $('#storyList').innerHTML = `<div class="empty">${esc(e.message)}</div>`;
   }
 }
 
@@ -611,10 +515,10 @@ function renderOverview(data) {
               return [short, `Polarization: ${p.y.toFixed(2)}`, `Articles: ${p.x}`];
             },
           },
-          backgroundColor: 'rgba(12,12,16,0.95)',
-          titleColor: '#ededf0',
-          bodyColor: '#b0b0be',
-          borderColor: 'rgba(255,255,255,0.08)',
+          backgroundColor: '#1a1a1e',
+          titleColor: '#fafafa',
+          bodyColor: '#a1a1aa',
+          borderColor: 'rgba(255,255,255,0.06)',
           borderWidth: 1,
           padding: 12,
           cornerRadius: 10,
@@ -622,12 +526,12 @@ function renderOverview(data) {
       },
       scales: {
         x: {
-          title: { display: true, text: 'Article Count', color: '#6e6e82', font: { size: 11 } },
-          grid: { color: 'rgba(34,34,48,0.4)' },
+          title: { display: true, text: 'Article Count', color: '#63636e', font: { size: 11, family: "'Inter', sans-serif" } },
+          grid: { color: 'rgba(255,255,255,0.04)' },
         },
         y: {
-          title: { display: true, text: 'Polarization Score', color: '#6e6e82', font: { size: 11 } },
-          grid: { color: 'rgba(34,34,48,0.4)' },
+          title: { display: true, text: 'Polarization Score', color: '#63636e', font: { size: 11, family: "'Inter', sans-serif" } },
+          grid: { color: 'rgba(255,255,255,0.04)' },
         },
       },
       onClick: (e, elements) => {
@@ -645,7 +549,7 @@ function renderOverview(data) {
 
 function renderStories(data) {
   if (!data.length) {
-    $('#storyList').innerHTML = '<div class="empty-state">No polarized stories found</div>';
+    $('#storyList').innerHTML = '<div class="empty">No polarized stories found</div>';
     return;
   }
 
@@ -671,7 +575,7 @@ function renderStories(data) {
       </div>`;
     }).join('');
 
-    return `<div class="pol-card" data-id="${d.id}" ${delay} onclick="openDetail('${d.id}')">
+    return `<div class="pol-card animate-in" data-id="${d.id}" ${delay} onclick="openDetail('${d.id}')">
       <div class="pol-card-top">
         <span class="pol-card-title">${esc(d.title || '(untitled)')}</span>
         <span class="pol-score ${scoreClass(d.polarization_score)}">${d.polarization_score.toFixed(2)}</span>
@@ -720,7 +624,7 @@ async function openDetail(id) {
 
     // Stats
     $('#detailStats').innerHTML = `
-      <div class="detail-stat"><div class="detail-stat-val" style="color:var(--primary-light)">${d.polarization_score.toFixed(2)}</div><div class="detail-stat-label">Polarization</div></div>
+      <div class="detail-stat"><div class="detail-stat-val" style="color:var(--accent-text)">${d.polarization_score.toFixed(2)}</div><div class="detail-stat-label">Polarization</div></div>
       <div class="detail-stat"><div class="detail-stat-val" style="color:${toneColor(d.avg_tone)}">${d.avg_tone > 0 ? '+' : ''}${d.avg_tone.toFixed(2)}</div><div class="detail-stat-label">Avg Tone</div></div>
       <div class="detail-stat"><div class="detail-stat-val" style="color:var(--negative)">${d.tone_min.toFixed(1)}</div><div class="detail-stat-label">Most Negative</div></div>
       <div class="detail-stat"><div class="detail-stat-val" style="color:var(--positive)">+${d.tone_max.toFixed(1)}</div><div class="detail-stat-label">Most Positive</div></div>
@@ -733,7 +637,7 @@ async function openDetail(id) {
     renderDetailSources(d);
 
   } catch (e) {
-    $('#detailStats').innerHTML = `<div class="empty-state">${esc(e.message)}</div>`;
+    $('#detailStats').innerHTML = `<div class="empty">${esc(e.message)}</div>`;
   }
 }
 
@@ -753,9 +657,9 @@ function renderDetailHistogram(d) {
   const labels = Object.keys(buckets).map(Number).sort((a, b) => a - b);
   const values = labels.map(l => buckets[l]);
   const colors = labels.map(l => {
-    if (l < -1) return 'rgba(229, 99, 122, 0.7)';
-    if (l > 0) return 'rgba(45, 212, 168, 0.7)';
-    return 'rgba(110, 110, 130, 0.5)';
+    if (l < -1) return 'rgba(248, 113, 113, 0.6)';
+    if (l > 0) return 'rgba(52, 211, 153, 0.6)';
+    return 'rgba(99, 99, 110, 0.4)';
   });
 
   const ctx = $('#detailHistChart').getContext('2d');
@@ -783,9 +687,9 @@ function renderDetailHistogram(d) {
             title: ctx => `Tone ${ctx[0].label} to ${Number(ctx[0].label) + 1}`,
             label: ctx => `${ctx.raw} articles`,
           },
-          backgroundColor: 'rgba(12,12,16,0.95)',
-          bodyColor: '#b0b0be',
-          borderColor: 'rgba(255,255,255,0.08)',
+          backgroundColor: '#1a1a1e',
+          bodyColor: '#a1a1aa',
+          borderColor: 'rgba(255,255,255,0.06)',
           borderWidth: 1,
           padding: 10,
           cornerRadius: 8,
@@ -793,12 +697,12 @@ function renderDetailHistogram(d) {
       },
       scales: {
         x: {
-          title: { display: true, text: 'Tone Score', color: '#6e6e82', font: { size: 11 } },
+          title: { display: true, text: 'Tone Score', color: '#63636e', font: { size: 11, family: "'Inter', sans-serif" } },
           grid: { display: false },
         },
         y: {
-          title: { display: true, text: 'Articles', color: '#6e6e82', font: { size: 11 } },
-          grid: { color: 'rgba(34,34,48,0.4)' },
+          title: { display: true, text: 'Articles', color: '#63636e', font: { size: 11, family: "'Inter', sans-serif" } },
+          grid: { color: 'rgba(255,255,255,0.04)' },
         },
       },
     },
@@ -824,8 +728,8 @@ function renderDetailSourceChart(d) {
       }),
       datasets: [{
         data: sources.map(s => s.avg_tone),
-        backgroundColor: sources.map(s => toneColorRgba(s.avg_tone, 0.7)),
-        borderColor: sources.map(s => toneColorRgba(s.avg_tone, 1)),
+        backgroundColor: sources.map(s => toneColorRgba(s.avg_tone, 0.6)),
+        borderColor: sources.map(s => toneColorRgba(s.avg_tone, 0.9)),
         borderWidth: 1,
         borderRadius: 3,
         barPercentage: 0.7,
@@ -844,9 +748,9 @@ function renderDetailSourceChart(d) {
               return [`Avg tone: ${s.avg_tone > 0 ? '+' : ''}${s.avg_tone.toFixed(2)}`, `${s.article_count} articles`];
             },
           },
-          backgroundColor: 'rgba(12,12,16,0.95)',
-          bodyColor: '#b0b0be',
-          borderColor: 'rgba(255,255,255,0.08)',
+          backgroundColor: '#1a1a1e',
+          bodyColor: '#a1a1aa',
+          borderColor: 'rgba(255,255,255,0.06)',
           borderWidth: 1,
           padding: 10,
           cornerRadius: 8,
@@ -854,12 +758,12 @@ function renderDetailSourceChart(d) {
       },
       scales: {
         x: {
-          title: { display: true, text: 'Average Tone', color: '#6e6e82', font: { size: 11 } },
-          grid: { color: 'rgba(34,34,48,0.4)' },
+          title: { display: true, text: 'Average Tone', color: '#63636e', font: { size: 11, family: "'Inter', sans-serif" } },
+          grid: { color: 'rgba(255,255,255,0.04)' },
         },
         y: {
           grid: { display: false },
-          ticks: { font: { size: 11 } },
+          ticks: { font: { size: 11, family: "'Inter', sans-serif" } },
         },
       },
     },

--- a/src/gdelt_event_pipeline/api/static/propagation.html
+++ b/src/gdelt_event_pipeline/api/static/propagation.html
@@ -3,131 +3,344 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="theme-color" content="#0d1127">
-<title>Story Propagation — Pulse</title>
+<meta name="theme-color" content="#09090b">
+<title>Story Propagation — GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --bg:#0d1127;
-  --bg2:#131838;
-  --card:rgba(20,26,56,.82);
-  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
-  --text:#e8ecf8;
-  --text2:rgba(232,236,248,.55);
-  --text3:rgba(232,236,248,.3);
-  --accent:#2ee8a5;
-  --accent-soft:rgba(46,232,165,.1);
-  --positive:#2ee8a5;--negative:#ff6b6b;
-  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
-  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
-  --society:#ff9f43;--general:#8899bb;
-  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
-  --mono:'JetBrains Mono',monospace;
-  --r:16px;
+/* ── Page-specific layout ─────────────────────────────── */
+.prop-layout {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 0;
+  min-height: calc(100dvh - 180px);
 }
-body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100dvh;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-a{color:var(--accent);text-decoration:none}
+@media (max-width: 900px) {
+  .prop-layout { grid-template-columns: 1fr; min-height: auto; }
+}
 
-/* ── TOP BAR ──────────────────── */
-.bar{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 28px;background:rgba(13,17,39,.85);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.04)}
-.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em;cursor:pointer}
-.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
-@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
-.bar-right{display:flex;align-items:center;gap:12px}
-.bar-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text2);padding:7px 16px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.08);background:none;transition:all .2s}
-.bar-btn:hover{color:var(--text);border-color:rgba(255,255,255,.15);background:rgba(255,255,255,.03)}
+/* ── Story list (left panel) ──────────────────────────── */
+.story-list {
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  max-height: calc(100dvh - 180px);
+  padding: var(--sp-4);
+}
+@media (max-width: 900px) {
+  .story-list {
+    max-height: 300px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+}
 
-/* ── LAYOUT ──────────────────── */
-.hero{text-align:center;padding:48px 28px 32px}
-.hero h1{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1.1;margin-bottom:10px}
-.hero h1 span{color:var(--accent)}
-.hero p{font-size:14px;color:var(--text2);max-width:540px;margin:0 auto;line-height:1.6}
+.story-list-heading {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  padding: 0 var(--sp-2) var(--sp-3);
+}
 
-.two-col{display:grid;grid-template-columns:340px 1fr;gap:0;min-height:calc(100dvh - 180px)}
-@media(max-width:900px){.two-col{grid-template-columns:1fr;min-height:auto}}
+.story-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  margin-bottom: var(--sp-2);
+  cursor: pointer;
+  transition: border-color var(--duration) var(--ease), background var(--duration) var(--ease);
+}
+.story-card:hover {
+  border-color: var(--border-hover);
+  background: var(--surface-2);
+}
+.story-card.active {
+  border-color: var(--border-active);
+  background: var(--surface-2);
+}
 
-/* ── STORY LIST (left) ───────── */
-.story-list{border-right:1px solid rgba(255,255,255,.04);overflow-y:auto;max-height:calc(100dvh - 180px);padding:16px}
-@media(max-width:900px){.story-list{max-height:300px;border-right:none;border-bottom:1px solid rgba(255,255,255,.04)}}
-.story-list h3{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);padding:0 8px 12px}
-.story-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:14px 16px;margin-bottom:8px;cursor:pointer;transition:all .2s;box-shadow:var(--card-sh)}
-.story-card:hover{background:rgba(30,38,72,.85);border-color:rgba(255,255,255,.09)}
-.story-card.active{border-color:var(--accent);background:rgba(46,232,165,.06)}
-.story-title{font-size:13px;font-weight:600;line-height:1.35;margin-bottom:8px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
-.story-meta{display:flex;gap:10px;font-size:10px;color:var(--text3);font-family:var(--mono)}
-.story-meta .pill{background:rgba(46,232,165,.1);color:var(--accent);padding:2px 8px;border-radius:100px;font-weight:600}
+.story-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-bottom: var(--sp-2);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--text);
+}
 
-/* ── DETAIL PANEL (right) ────── */
-.detail{padding:24px;overflow-y:auto;max-height:calc(100dvh - 180px)}
-@media(max-width:900px){.detail{max-height:none}}
-.detail-empty{display:flex;align-items:center;justify-content:center;height:300px;color:var(--text3);font-size:14px}
-.detail-head{margin-bottom:24px}
-.detail-head h2{font-size:20px;font-weight:700;letter-spacing:-.02em;line-height:1.3;margin-bottom:8px}
-.detail-stats{display:flex;gap:16px;flex-wrap:wrap}
-.d-stat{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);border-radius:12px;padding:12px 18px;text-align:center}
-.d-stat-val{font-size:22px;font-weight:700;font-family:var(--mono)}
-.d-stat-lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:2px}
+.story-meta {
+  display: flex;
+  gap: var(--sp-2);
+  align-items: center;
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+}
 
-/* ── HISTOGRAM ───────────────── */
-.chart-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:20px;margin-bottom:20px;box-shadow:var(--card-sh)}
-.chart-card h4{font-size:13px;font-weight:700;margin-bottom:4px}
-.chart-card .chart-sub{font-size:10px;color:var(--text3);margin-bottom:14px}
-.chart-wrap{position:relative;height:200px}
+.story-meta .pill {
+  background: var(--accent-dim);
+  color: var(--accent-text);
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-weight: 500;
+  font-size: 0.6875rem;
+}
 
-/* ── TIMELINE ────────────────── */
-.timeline{position:relative;padding-left:24px;margin-top:24px}
-.timeline::before{content:'';position:absolute;left:7px;top:0;bottom:0;width:2px;background:linear-gradient(180deg,var(--accent),rgba(46,232,165,.1))}
-.tl-item{position:relative;padding-bottom:20px}
-.tl-dot{position:absolute;left:-21px;top:4px;width:12px;height:12px;border-radius:50%;border:2px solid var(--accent);background:var(--bg)}
-.tl-item.first .tl-dot{background:var(--accent);box-shadow:0 0 8px rgba(46,232,165,.4)}
-.tl-time{font-size:10px;font-family:var(--mono);color:var(--text3);margin-bottom:4px}
-.tl-source{font-size:11px;font-weight:700;color:var(--accent);margin-bottom:2px}
-.tl-title{font-size:13px;font-weight:500;line-height:1.4;color:var(--text)}
-.tl-title a{color:var(--text);transition:color .15s}
-.tl-title a:hover{color:var(--accent)}
-.tl-tone{display:inline-block;font-size:10px;font-weight:700;font-family:var(--mono);padding:1px 7px;border-radius:100px;margin-top:4px}
+/* ── Detail panel (right) ─────────────────────────────── */
+.detail {
+  padding: var(--sp-5);
+  overflow-y: auto;
+  max-height: calc(100dvh - 180px);
+}
+@media (max-width: 900px) {
+  .detail { max-height: none; }
+}
 
-/* ── SOURCE SPREAD ───────────── */
-.source-spread{margin-top:20px}
-.source-spread h4{font-size:13px;font-weight:700;margin-bottom:14px}
-.spread-bar{display:flex;align-items:center;gap:10px;margin-bottom:8px}
-.spread-name{font-size:12px;font-weight:600;width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.spread-track{flex:1;height:8px;background:rgba(255,255,255,.04);border-radius:4px;position:relative;overflow:hidden}
-.spread-fill{height:100%;border-radius:4px;transition:width .4s ease}
-.spread-count{font-size:11px;font-family:var(--mono);color:var(--text3);width:40px;text-align:right}
+.detail-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  color: var(--text-3);
+  font-size: 0.875rem;
+}
 
-/* ── LOADING ─────────────────── */
-.loading{display:flex;align-items:center;justify-content:center;padding:60px;color:var(--text3);gap:10px;font-size:13px}
-.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.08);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite}
-@keyframes spin{to{transform:rotate(360deg)}}
+.detail-head {
+  margin-bottom: var(--sp-5);
+}
+
+.detail-head h2 {
+  font-size: clamp(1.125rem, 2vw, 1.25rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  margin-bottom: var(--sp-3);
+  color: var(--text);
+}
+
+.detail-stats {
+  display: flex;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.d-stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  text-align: center;
+}
+
+.d-stat-val {
+  font-size: 1.25rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.d-stat-lbl {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  margin-top: 2px;
+}
+
+/* ── Chart card ───────────────────────────────────────── */
+.chart-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+  margin-bottom: var(--sp-5);
+}
+
+.chart-card h4 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: var(--sp-1);
+  color: var(--text);
+}
+
+.chart-card .chart-sub {
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  margin-bottom: var(--sp-4);
+}
+
+.chart-wrap {
+  position: relative;
+  height: 200px;
+}
+
+/* ── Source spread ────────────────────────────────────── */
+.source-spread {
+  margin-top: var(--sp-5);
+}
+
+.source-spread h4 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: var(--sp-4);
+  color: var(--text);
+}
+
+.spread-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-2);
+}
+
+.spread-name {
+  font-size: 0.75rem;
+  font-weight: 500;
+  width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spread-track {
+  flex: 1;
+  height: 6px;
+  background: var(--surface-2);
+  border-radius: 3px;
+  position: relative;
+  overflow: hidden;
+}
+
+.spread-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.4s var(--ease);
+}
+
+.spread-count {
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+  width: 40px;
+  text-align: right;
+}
+
+/* ── Timeline ─────────────────────────────────────────── */
+.timeline {
+  position: relative;
+  padding-left: 24px;
+  margin-top: var(--sp-5);
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 7px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+}
+
+.tl-item {
+  position: relative;
+  padding-bottom: var(--sp-5);
+}
+
+.tl-dot {
+  position: absolute;
+  left: -21px;
+  top: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--text-3);
+  background: var(--bg);
+}
+
+.tl-item.first .tl-dot {
+  background: var(--text-2);
+  border-color: var(--text-2);
+}
+
+.tl-time {
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+  margin-bottom: 3px;
+}
+
+.tl-source {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.tl-title {
+  font-size: 0.8125rem;
+  font-weight: 450;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+.tl-title a {
+  color: var(--text);
+  transition: color var(--duration);
+}
+.tl-title a:hover {
+  color: var(--text-2);
+}
+
+.tl-tone {
+  display: inline-block;
+  font-size: 0.625rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  margin-top: var(--sp-1);
+}
+
+/* ── Section heading ──────────────────────────────────── */
+.section-heading {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: var(--sp-4);
+  color: var(--text);
+}
 </style>
 </head>
 <body>
 
 <!-- TOP BAR -->
-<header class="bar">
-  <div class="brand" onclick="location.href='/'"><i></i> Pulse</div>
-  <div class="bar-right">
-    <button class="bar-btn" onclick="location.href='/globe'">Globe</button>
-    <button class="bar-btn" onclick="location.href='/'">Home</button>
-  </div>
-</header>
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+</nav>
 
-<!-- HERO -->
-<section class="hero">
-  <h1>Story <span>Propagation</span></h1>
+<!-- PAGE INTRO -->
+<section class="page-intro">
+  <h1>Story <span style="color:var(--text-3)">Propagation</span></h1>
   <p>Track how breaking news spreads across media outlets over time. See which sources break stories first and how coverage cascades.</p>
 </section>
 
 <!-- MAIN LAYOUT -->
-<div class="two-col">
+<div class="prop-layout">
   <!-- LEFT: story list -->
   <div class="story-list" id="storyList">
-    <h3>Top Multi-Source Stories</h3>
-    <div class="loading">Loading<span class="spinner"></span></div>
+    <div class="story-list-heading">Top Multi-Source Stories</div>
+    <div class="loading"><span class="spinner"></span>Loading</div>
   </div>
 
   <!-- RIGHT: detail panel -->
@@ -149,14 +362,14 @@ async function init() {
     renderStoryList();
     if (stories.length > 0) selectStory(stories[0].id);
   } catch (e) {
-    document.getElementById('storyList').innerHTML = '<div style="padding:40px;text-align:center;color:var(--text3)">Failed to load stories</div>';
+    document.getElementById('storyList').innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-3)">Failed to load stories</div>';
   }
 }
 
 // ── STORY LIST ───────────────────────────────────────────────────────
 function renderStoryList() {
   const el = document.getElementById('storyList');
-  el.innerHTML = '<h3>Top Multi-Source Stories</h3>' + stories.map(s => {
+  el.innerHTML = '<div class="story-list-heading">Top Multi-Source Stories</div>' + stories.map(s => {
     const span = s.span_hours > 24 ? `${Math.round(s.span_hours / 24)}d` : `${Math.round(s.span_hours)}h`;
     return `<div class="story-card" data-id="${s.id}" onclick="selectStory('${s.id}')">
       <div class="story-title">${esc(s.title)}</div>
@@ -174,7 +387,7 @@ async function selectStory(id) {
   activeStory = id;
   document.querySelectorAll('.story-card').forEach(c => c.classList.toggle('active', c.dataset.id === id));
   const detail = document.getElementById('detail');
-  detail.innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  detail.innerHTML = '<div class="loading"><span class="spinner"></span>Loading</div>';
 
   try {
     const res = await fetch(`/api/propagation/${id}`);
@@ -192,9 +405,9 @@ function renderDetail(d) {
     ? Math.round((new Date(d.last_article_at) - new Date(d.first_article_at)) / 3600000)
     : 0;
 
-  // Source colors
+  // Source colors — muted palette matching design system
   const srcColors = {};
-  const palette = ['#2ee8a5','#7b8aff','#ff6b6b','#ffc844','#22d4e6','#a78bfa','#ff9f43','#60a5fa','#e879f9','#34d399','#f97316','#818cf8'];
+  const palette = ['#a1a1aa','#818cf8','#f87171','#fbbf24','#22d3ee','#a78bfa','#fb923c','#60a5fa','#e879f9','#34d399','#f97316','#71717a'];
   d.sources.forEach((s, i) => { srcColors[s.domain] = palette[i % palette.length]; });
 
   const maxArticles = Math.max(...d.sources.map(s => s.article_count));
@@ -231,13 +444,13 @@ function renderDetail(d) {
           <span class="spread-name" style="color:${col}">${esc(s.source_name)}</span>
           <div class="spread-track"><div class="spread-fill" style="width:${pct}%;background:${col}"></div></div>
           <span class="spread-count">${s.article_count}</span>
-          <span style="font-size:10px;font-family:var(--mono);color:${s.order === 0 ? 'var(--accent)' : 'var(--text3)'};width:50px;text-align:right;font-weight:${s.order === 0 ? '700' : '400'}">${delay}</span>
+          <span style="font-size:0.625rem;font-variant-numeric:tabular-nums;color:${s.order === 0 ? 'var(--text)' : 'var(--text-3)'};width:50px;text-align:right;font-weight:${s.order === 0 ? '600' : '400'}">${delay}</span>
         </div>`;
       }).join('')}
     </div>
 
-    <div style="margin-top:28px">
-      <h4 style="font-size:13px;font-weight:700;margin-bottom:16px">Propagation Timeline</h4>
+    <div style="margin-top:var(--sp-6)">
+      <h4 class="section-heading">Propagation Timeline</h4>
       <div class="timeline">
         ${d.timeline.map((e, i) => {
           const col = srcColors[e.domain];
@@ -248,7 +461,7 @@ function renderDetail(d) {
           return `<div class="tl-item ${e.is_first_from_source ? 'first' : ''}">
             <div class="tl-dot" style="border-color:${col};${e.is_first_from_source ? `background:${col}` : ''}"></div>
             <div class="tl-time">${time}</div>
-            <div class="tl-source" style="color:${col}">${esc(e.source_name)} ${e.is_first_from_source ? '<span style="font-size:9px;background:'+col+'22;padding:1px 6px;border-radius:100px">NEW SOURCE</span>' : ''}</div>
+            <div class="tl-source" style="color:${col}">${esc(e.source_name)} ${e.is_first_from_source ? '<span style="font-size:0.5625rem;background:'+col+'18;padding:1px 6px;border-radius:var(--radius-full);font-weight:500">NEW SOURCE</span>' : ''}</div>
             <div class="tl-title"><a href="${esc(e.url)}" target="_blank">${esc(e.title)}</a></div>
             ${e.tone != null ? `<span class="tl-tone" style="background:${toneCol}18;color:${toneCol}">${e.tone >= 0 ? '+' : ''}${e.tone}</span>` : ''}
           </div>`;
@@ -276,11 +489,11 @@ function renderHistogram(data) {
       labels: data.map(d => `+${d.hour}h`),
       datasets: [{
         data: data.map(d => d.count),
-        backgroundColor: 'rgba(46,232,165,.3)',
-        borderColor: '#2ee8a5',
-        borderWidth: 1.5,
+        backgroundColor: 'rgba(161,161,170,.15)',
+        borderColor: 'rgba(161,161,170,.4)',
+        borderWidth: 1,
         borderRadius: 4,
-        hoverBackgroundColor: 'rgba(46,232,165,.5)'
+        hoverBackgroundColor: 'rgba(161,161,170,.25)'
       }]
     },
     options: {
@@ -289,23 +502,26 @@ function renderHistogram(data) {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: 'rgba(13,17,39,.95)',
-          borderColor: 'rgba(255,255,255,.08)',
+          backgroundColor: 'rgba(9,9,11,0.95)',
+          borderColor: 'rgba(255,255,255,0.06)',
           borderWidth: 1,
-          bodyFont: { family: "'JetBrains Mono'", size: 11 },
+          titleFont: { family: "'Inter'", size: 11, weight: 500 },
+          bodyFont: { family: "'Inter'", size: 11 },
           padding: 10,
           cornerRadius: 8,
+          titleColor: '#fafafa',
+          bodyColor: '#a1a1aa',
           callbacks: { label: ctx => `${ctx.raw} articles` }
         }
       },
       scales: {
         x: {
-          grid: { color: 'rgba(255,255,255,.03)' },
-          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 }, maxTicksLimit: 12 }
+          grid: { color: 'rgba(255,255,255,0.03)' },
+          ticks: { color: '#63636e', font: { family: "'Inter'", size: 10 }, maxTicksLimit: 12 }
         },
         y: {
-          grid: { color: 'rgba(255,255,255,.03)' },
-          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 }, stepSize: 1 }
+          grid: { color: 'rgba(255,255,255,0.03)' },
+          ticks: { color: '#63636e', font: { family: "'Inter'", size: 10 }, stepSize: 1 }
         }
       }
     }

--- a/src/gdelt_event_pipeline/api/static/pulse.css
+++ b/src/gdelt_event_pipeline/api/static/pulse.css
@@ -1,0 +1,669 @@
+/* ═══════════════════════════════════════════════════════
+   GDELT Pulse — Design System
+   Inspired by Bending Spoons: editorial, premium, clean.
+   ═══════════════════════════════════════════════════════ */
+
+/* ── Reset ─────────────────────────────────────────────── */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+/* ── Design Tokens ─────────────────────────────────────── */
+:root {
+  /* Backgrounds */
+  --bg:         #09090b;
+  --bg-subtle:  #0f0f11;
+  --surface:    #141416;
+  --surface-2:  #1a1a1e;
+  --surface-3:  #222226;
+
+  /* Borders */
+  --border:      rgba(255, 255, 255, 0.06);
+  --border-hover: rgba(255, 255, 255, 0.10);
+  --border-active: rgba(255, 255, 255, 0.14);
+
+  /* Text */
+  --text:   #fafafa;
+  --text-2: #a1a1aa;
+  --text-3: #63636e;
+
+  /* Accent — restrained, not neon */
+  --accent:     #8b8bf5;
+  --accent-dim: rgba(139, 139, 245, 0.08);
+  --accent-text: #b4b4fc;
+
+  /* Semantic colors (data only, not UI chrome) */
+  --positive: #34d399;
+  --negative: #f87171;
+  --warning:  #fbbf24;
+  --info:     #60a5fa;
+
+  /* Category colors — muted palette */
+  --cat-conflict:    #f87171;
+  --cat-economy:     #fbbf24;
+  --cat-politics:    #818cf8;
+  --cat-health:      #34d399;
+  --cat-environment: #22d3ee;
+  --cat-technology:  #a78bfa;
+  --cat-society:     #fb923c;
+  --cat-general:     #71717a;
+
+  /* Typography */
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+
+  /* Spacing scale (4px base) */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+  --sp-9: 96px;
+  --sp-10: 128px;
+
+  /* Radii */
+  --radius-sm: 8px;
+  --radius:    12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-full: 9999px;
+
+  /* Motion */
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --duration: 0.2s;
+  --duration-lg: 0.4s;
+}
+
+/* ── Base ──────────────────────────────────────────────── */
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+  min-height: 100vh;
+  font-feature-settings: 'cv11' 1, 'ss01' 1; /* Inter alternates */
+}
+
+::selection {
+  background: rgba(139, 139, 245, 0.2);
+  color: var(--text);
+}
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-3); }
+
+a { color: inherit; text-decoration: none; }
+button { font-family: var(--font); }
+img { display: block; max-width: 100%; }
+
+/* ── Typography ────────────────────────────────────────── */
+.t-display {
+  font-size: clamp(2.8rem, 6vw, 4.5rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+}
+
+.t-h1 {
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.t-h2 {
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.t-h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.35;
+}
+
+.t-body { font-size: 0.9375rem; line-height: 1.6; }
+.t-small { font-size: 0.8125rem; line-height: 1.55; }
+.t-caption { font-size: 0.75rem; line-height: 1.5; }
+.t-overline {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.t-num {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+.t-muted { color: var(--text-2); }
+.t-dim { color: var(--text-3); }
+
+/* ── Layout ────────────────────────────────────────────── */
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 var(--sp-5);
+}
+
+.container-narrow {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 var(--sp-5);
+}
+
+.container-wide {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 var(--sp-5);
+}
+
+/* ── Navigation / Topbar ───────────────────────────────── */
+.topbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--sp-5);
+  background: rgba(9, 9, 11, 0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  transition: background var(--duration) var(--ease);
+}
+
+.topbar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-weight: 600;
+  font-size: 0.9375rem;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.topbar-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.topbar-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  margin-left: auto;
+}
+
+.topbar-link {
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 450;
+  color: var(--text-3);
+  transition: color var(--duration), background var(--duration);
+  cursor: pointer;
+  border: none;
+  background: none;
+  text-decoration: none;
+}
+
+.topbar-link:hover { color: var(--text); }
+.topbar-link.active {
+  color: var(--text);
+  background: var(--surface);
+}
+
+/* Back button for subpages */
+.topbar-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 450;
+  color: var(--text-3);
+  cursor: pointer;
+  border: none;
+  background: none;
+  transition: color var(--duration);
+  text-decoration: none;
+}
+.topbar-back:hover { color: var(--text); }
+.topbar-back svg { width: 14px; height: 14px; }
+
+/* ── Buttons ───────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  padding: 10px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-family: var(--font);
+  color: var(--text-2);
+  background: transparent;
+  cursor: pointer;
+  transition: all var(--duration) var(--ease);
+  white-space: nowrap;
+}
+
+.btn:hover {
+  color: var(--text);
+  border-color: var(--border-hover);
+  background: var(--surface);
+}
+
+.btn:active { transform: scale(0.98); }
+.btn:disabled { opacity: 0.35; pointer-events: none; }
+
+.btn-primary {
+  background: var(--text);
+  color: var(--bg);
+  border-color: var(--text);
+}
+.btn-primary:hover {
+  background: var(--text-2);
+  border-color: var(--text-2);
+  color: var(--bg);
+}
+
+.btn-sm { padding: 7px 14px; font-size: 0.8125rem; }
+.btn-lg { padding: 14px 28px; font-size: 0.9375rem; }
+.btn-icon { padding: 8px; }
+
+.btn svg { width: 16px; height: 16px; flex-shrink: 0; }
+
+/* ── Cards ─────────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+  transition: border-color var(--duration) var(--ease), background var(--duration) var(--ease);
+}
+
+.card:hover {
+  border-color: var(--border-hover);
+}
+
+.card-interactive {
+  cursor: pointer;
+}
+.card-interactive:hover {
+  border-color: var(--border-active);
+  background: var(--surface-2);
+}
+
+/* ── Stat cards ────────────────────────────────────────── */
+.stat-grid {
+  display: grid;
+  gap: var(--sp-3);
+}
+
+.stat-grid-3 { grid-template-columns: repeat(3, 1fr); }
+.stat-grid-4 { grid-template-columns: repeat(4, 1fr); }
+
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-5) var(--sp-4);
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: var(--text-3);
+  font-weight: 450;
+}
+
+/* ── Tags / Badges ─────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  background: var(--surface-2);
+  color: var(--text-2);
+  border: 1px solid var(--border);
+}
+
+.badge-accent {
+  background: var(--accent-dim);
+  color: var(--accent-text);
+  border-color: rgba(139, 139, 245, 0.12);
+}
+
+.tag {
+  display: inline-flex;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.tag-loc { color: var(--positive); background: rgba(52, 211, 153, 0.08); }
+.tag-per { color: var(--warning); background: rgba(251, 191, 36, 0.08); }
+.tag-org { color: var(--negative); background: rgba(248, 113, 113, 0.08); }
+
+/* ── Inputs ────────────────────────────────────────────── */
+.input {
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-family: var(--font);
+  outline: none;
+  transition: border-color var(--duration), box-shadow var(--duration);
+}
+
+.input:focus {
+  border-color: var(--border-active);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.03);
+}
+
+.input::placeholder { color: var(--text-3); }
+
+.input-lg {
+  padding: 14px 18px;
+  font-size: 1rem;
+  border-radius: var(--radius-lg);
+}
+
+/* Range slider */
+input[type="range"] {
+  accent-color: var(--text-2);
+  height: 4px;
+}
+
+/* Select */
+.select {
+  padding: 8px 12px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-2);
+  font-size: 0.8125rem;
+  font-family: var(--font);
+  outline: none;
+  cursor: pointer;
+}
+.select:focus { border-color: var(--border-active); }
+
+/* ── Tables ────────────────────────────────────────────── */
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.table th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-2);
+}
+
+.table tr:last-child td { border-bottom: none; }
+
+.table tr:hover td { background: var(--surface-2); }
+
+.table th.sortable { cursor: pointer; }
+.table th.sortable:hover { color: var(--text-2); }
+.table th.sorted { color: var(--text); }
+
+/* ── Modal / Overlay ───────────────────────────────────── */
+.overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 200;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-5);
+}
+
+.overlay.open {
+  display: flex;
+  animation: fadeIn 0.15s var(--ease-out);
+}
+
+.modal {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 700px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: var(--sp-6);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: modalIn 0.2s var(--ease);
+}
+
+.modal::-webkit-scrollbar { width: 4px; }
+.modal::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: 2px; }
+
+.modal-close {
+  float: right;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-3);
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--duration);
+}
+.modal-close:hover { color: var(--text); border-color: var(--border-hover); }
+
+/* ── Loading States ────────────────────────────────────── */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-3);
+  padding: var(--sp-8) var(--sp-5);
+  color: var(--text-3);
+  font-size: 0.875rem;
+}
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--surface-3);
+  border-top-color: var(--text-3);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+.empty {
+  text-align: center;
+  padding: var(--sp-8) var(--sp-5);
+  color: var(--text-3);
+  font-size: 0.875rem;
+}
+
+/* ── Divider ───────────────────────────────────────────── */
+.divider {
+  height: 1px;
+  background: var(--border);
+  margin: var(--sp-6) 0;
+}
+
+/* ── Page intro (hero) for subpages ────────────────────── */
+.page-intro {
+  text-align: center;
+  padding: var(--sp-10) var(--sp-5) var(--sp-7);
+}
+
+.page-intro h1 {
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  margin-bottom: var(--sp-3);
+}
+
+.page-intro p {
+  font-size: 0.9375rem;
+  color: var(--text-3);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ── Tooltip ───────────────────────────────────────────── */
+.tooltip {
+  position: fixed;
+  z-index: 100;
+  pointer-events: none;
+  padding: 10px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  color: var(--text-2);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  max-width: 280px;
+}
+
+/* ── Two-column layout ─────────────────────────────────── */
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-5);
+}
+
+/* ── Chart section ─────────────────────────────────────── */
+.chart-section {
+  margin-bottom: var(--sp-6);
+}
+
+.chart-section h3 {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+  margin-bottom: var(--sp-2);
+}
+
+.chart-section .chart-sub {
+  font-size: 0.75rem;
+  color: var(--text-3);
+  margin-bottom: var(--sp-4);
+}
+
+.chart-container {
+  position: relative;
+  height: 320px;
+}
+
+.chart-container.tall { height: 400px; }
+
+/* ── Animations ────────────────────────────────────────── */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes modalIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.animate-in {
+  animation: slideUp 0.5s var(--ease) both;
+}
+
+/* ── Responsive ────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .stat-grid-3, .stat-grid-4 { grid-template-columns: 1fr 1fr; }
+  .two-col { grid-template-columns: 1fr; }
+  .topbar-nav { display: none; }
+  .page-intro { padding: var(--sp-8) var(--sp-4) var(--sp-6); }
+  .container, .container-narrow { padding: 0 var(--sp-4); }
+}
+
+@media (max-width: 480px) {
+  .stat-grid-3, .stat-grid-4 { grid-template-columns: 1fr; }
+}

--- a/src/gdelt_event_pipeline/api/static/sources.html
+++ b/src/gdelt_event_pipeline/api/static/sources.html
@@ -3,198 +3,313 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="theme-color" content="#0d1127">
-<title>Source DNA — Pulse</title>
+<meta name="theme-color" content="#09090b">
+<title>Source DNA — GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --bg:#0d1127;
-  --bg2:#131838;
-  --card:rgba(20,26,56,.82);
-  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
-  --text:#e8ecf8;
-  --text2:rgba(232,236,248,.55);
-  --text3:rgba(232,236,248,.3);
-  --accent:#2ee8a5;
-  --accent-soft:rgba(46,232,165,.1);
-  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
-  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
-  --society:#ff9f43;--general:#8899bb;
-  --positive:#2ee8a5;--negative:#ff6b6b;
-  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
-  --mono:'JetBrains Mono',monospace;
-  --r:16px;
+/* ── Page-specific styles (extending pulse.css) ── */
+
+.sort-controls {
+  display: flex;
+  justify-content: center;
+  gap: var(--sp-2);
+  padding: 0 var(--sp-5) var(--sp-6);
+  flex-wrap: wrap;
 }
-body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100dvh;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-a{color:var(--accent);text-decoration:none}
 
-/* ── TOP BAR ──────────────────── */
-.bar{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 28px;background:rgba(13,17,39,.85);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.04)}
-.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em;cursor:pointer}
-.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
-@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
-.bar-right{display:flex;align-items:center;gap:12px}
-.bar-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text2);padding:7px 16px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.08);background:none;transition:all .2s}
-.bar-btn:hover{color:var(--text);border-color:rgba(255,255,255,.15);background:rgba(255,255,255,.03)}
+.sort-controls .btn.active {
+  color: var(--text);
+  background: var(--surface-2);
+  border-color: var(--border-active);
+}
 
-/* ── HERO ─────────────────────── */
-.hero{text-align:center;padding:48px 28px 32px}
-.hero h1{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1.1;margin-bottom:10px}
-.hero h1 span{color:var(--accent)}
-.hero p{font-size:14px;color:var(--text2);max-width:520px;margin:0 auto;line-height:1.6}
+/* ── Stats row ── */
+.stats-row {
+  display: flex;
+  gap: var(--sp-3);
+  padding: 0 var(--sp-5) var(--sp-6);
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 1080px;
+  margin: 0 auto;
+}
 
-/* ── CONTROLS ─────────────────── */
-.controls{display:flex;justify-content:center;gap:8px;padding:0 28px 28px;flex-wrap:wrap}
-.ctrl-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text3);padding:7px 18px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.06);background:none;transition:all .25s}
-.ctrl-btn:hover{color:var(--text2);border-color:rgba(255,255,255,.12)}
-.ctrl-btn.on{color:var(--text);background:var(--accent-soft);border-color:var(--accent)}
+/* ── Scatter section ── */
+.scatter-section {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 var(--sp-5) var(--sp-6);
+}
 
-/* ── OVERVIEW STATS ──────────── */
-.stats-row{display:flex;gap:12px;padding:0 28px 28px;flex-wrap:wrap;justify-content:center}
-.stat-box{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:18px 24px;min-width:140px;text-align:center;box-shadow:var(--card-sh)}
-.stat-val{font-size:26px;font-weight:700;letter-spacing:-.02em;font-family:var(--mono)}
-.stat-lbl{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:4px}
+.scatter-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+}
 
-/* ── SCATTER CHART ───────────── */
-.chart-section{padding:0 28px 28px}
-.chart-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:24px;box-shadow:var(--card-sh)}
-.chart-title{font-size:14px;font-weight:700;margin-bottom:4px}
-.chart-sub{font-size:11px;color:var(--text3);margin-bottom:16px}
-.chart-wrap{position:relative;height:360px}
+.scatter-card .chart-wrap {
+  position: relative;
+  height: 360px;
+}
 
-/* ── SOURCE TABLE ────────────── */
-.table-section{padding:0 28px 40px}
-.table-wrap{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);overflow:hidden;box-shadow:var(--card-sh)}
-.table-header{display:flex;align-items:center;justify-content:space-between;padding:18px 20px 14px;border-bottom:1px solid rgba(255,255,255,.04)}
-.table-header h3{font-size:14px;font-weight:700}
-.table-search{font-family:var(--sans);font-size:12px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:100px;padding:7px 16px;color:var(--text);outline:none;width:220px;transition:border-color .2s}
-.table-search:focus{border-color:var(--accent)}
-.table-search::placeholder{color:var(--text3)}
-table{width:100%;border-collapse:collapse}
-thead th{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);text-align:left;padding:10px 16px;border-bottom:1px solid rgba(255,255,255,.04);cursor:pointer;user-select:none;white-space:nowrap;transition:color .2s}
-thead th:hover{color:var(--text2)}
-thead th.sorted{color:var(--accent)}
-thead th .arrow{font-size:8px;margin-left:4px}
-tbody tr{border-bottom:1px solid rgba(255,255,255,.02);transition:background .15s;cursor:pointer}
-tbody tr:hover{background:rgba(46,232,165,.03)}
-tbody td{padding:12px 16px;font-size:13px;white-space:nowrap}
-.src-name{font-weight:600;max-width:200px;overflow:hidden;text-overflow:ellipsis}
-.tone-bar{display:flex;height:6px;border-radius:3px;overflow:hidden;width:100px;background:rgba(255,255,255,.04)}
-.tone-pos{background:var(--positive);height:100%}
-.tone-neg{background:var(--negative);height:100%}
-.theme-tags{display:flex;gap:4px;flex-wrap:nowrap;max-width:200px;overflow:hidden}
-.theme-tag{font-size:9px;font-weight:600;padding:2px 7px;border-radius:100px;white-space:nowrap}
+/* ── Table extras ── */
+.table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-4) var(--sp-4) var(--sp-3);
+  border-bottom: 1px solid var(--border);
+}
 
-/* ── DETAIL MODAL ────────────── */
-.modal-bg{position:fixed;inset:0;z-index:200;background:rgba(0,0,0,.6);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);opacity:0;pointer-events:none;transition:opacity .3s}
-.modal-bg.on{opacity:1;pointer-events:auto}
-.modal{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(.95);z-index:201;width:min(720px,92vw);max-height:85vh;background:var(--bg2);border:1px solid rgba(255,255,255,.06);border-radius:calc(var(--r) + 4px);overflow:hidden;opacity:0;pointer-events:none;transition:all .35s cubic-bezier(.4,0,.2,1);display:flex;flex-direction:column}
-.modal-bg.on+.modal,.modal.on{opacity:1;pointer-events:auto;transform:translate(-50%,-50%) scale(1)}
-.modal-head{display:flex;align-items:center;justify-content:space-between;padding:20px 24px;border-bottom:1px solid rgba(255,255,255,.04)}
-.modal-head h2{font-size:18px;font-weight:700;letter-spacing:-.02em}
-.modal-head .domain-tag{font-size:11px;font-weight:500;color:var(--text2);font-family:var(--mono);margin-left:12px}
-.modal-close{width:32px;height:32px;border-radius:50%;border:none;background:rgba(255,255,255,.06);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;color:var(--text2);transition:background .2s}
-.modal-close:hover{background:rgba(255,255,255,.12)}
-.modal-body{padding:24px;overflow-y:auto;flex:1}
-.modal-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:24px}
-.m-stat{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);border-radius:12px;padding:14px;text-align:center}
-.m-stat-val{font-size:20px;font-weight:700;font-family:var(--mono)}
-.m-stat-lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:2px}
-.modal-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:24px}
-.modal-chart-card{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:12px;padding:16px}
-.modal-chart-card h4{font-size:12px;font-weight:700;margin-bottom:12px}
-.modal-chart-wrap{position:relative;height:200px}
-.recent-list{display:flex;flex-direction:column;gap:8px}
-.recent-item{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:12px;padding:12px 16px;transition:background .15s}
-.recent-item:hover{background:rgba(255,255,255,.04)}
-.recent-title{font-size:13px;font-weight:600;margin-bottom:4px;line-height:1.4}
-.recent-meta{font-size:10px;color:var(--text3);display:flex;gap:12px;align-items:center}
-.tone-chip{font-size:10px;font-weight:700;font-family:var(--mono);padding:2px 8px;border-radius:100px}
+.table-toolbar h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
 
-/* ── LOADING ─────────────────── */
-.loading{display:flex;align-items:center;justify-content:center;padding:60px;color:var(--text3);gap:10px;font-size:13px}
-.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.08);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite}
-@keyframes spin{to{transform:rotate(360deg)}}
+.src-name {
+  font-weight: 600;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-/* ── RESPONSIVE ──────────────── */
-@media(max-width:768px){
-  .hero h1{font-size:26px}
-  .stats-row{gap:8px}
-  .stat-box{min-width:100px;padding:14px 16px}
-  .stat-val{font-size:20px}
-  .chart-wrap{height:260px}
-  .modal-stats{grid-template-columns:repeat(2,1fr)}
-  .modal-grid{grid-template-columns:1fr}
-  .table-search{width:160px}
-  .theme-tags{display:none}
+.tone-bar {
+  display: flex;
+  height: 5px;
+  border-radius: 3px;
+  overflow: hidden;
+  width: 100px;
+  background: var(--surface-3);
+}
+
+.tone-pos { background: var(--positive); height: 100%; }
+.tone-neg { background: var(--negative); height: 100%; }
+
+.theme-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
+  max-width: 200px;
+  overflow: hidden;
+}
+
+.theme-tag {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+/* ── Modal internals ── */
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--sp-5);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--sp-5);
+}
+
+.modal-head h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.modal-head .domain-tag {
+  font-size: 0.75rem;
+  font-weight: 450;
+  color: var(--text-3);
+  margin-left: var(--sp-3);
+}
+
+.modal-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-5);
+}
+
+.m-stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-4);
+  text-align: center;
+}
+
+.m-stat-val {
+  font-size: 1.25rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.m-stat-lbl {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+  margin-top: 2px;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-5);
+}
+
+.modal-chart-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-4);
+}
+
+.modal-chart-card h4 {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-2);
+  margin-bottom: var(--sp-3);
+}
+
+.modal-chart-wrap {
+  position: relative;
+  height: 200px;
+}
+
+.recent-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.recent-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  transition: border-color var(--duration) var(--ease);
+}
+
+.recent-item:hover {
+  border-color: var(--border-hover);
+}
+
+.recent-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  margin-bottom: 4px;
+  line-height: 1.4;
+}
+
+.recent-meta {
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  display: flex;
+  gap: var(--sp-3);
+  align-items: center;
+}
+
+.tone-chip {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  padding: 2px 8px;
+  border-radius: 6px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .stats-row { gap: var(--sp-2); }
+  .scatter-card .chart-wrap { height: 260px; }
+  .modal-stats { grid-template-columns: repeat(2, 1fr); }
+  .modal-grid { grid-template-columns: 1fr; }
+  .theme-tags { display: none; }
 }
 </style>
 </head>
 <body>
 
-<!-- TOP BAR -->
-<header class="bar">
-  <div class="brand" onclick="location.href='/'"><i></i> Pulse</div>
-  <div class="bar-right">
-    <button class="bar-btn" onclick="location.href='/globe'">Globe</button>
-    <button class="bar-btn" onclick="location.href='/'">Home</button>
-  </div>
-</header>
+<!-- TOPBAR -->
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+</nav>
 
-<!-- HERO -->
-<section class="hero">
-  <h1>Source <span>DNA</span></h1>
-  <p>Fingerprint every news source by what they cover, how they cover it, and where they focus. Compare editorial DNA across thousands of outlets.</p>
+<!-- PAGE INTRO -->
+<section class="page-intro">
+  <h1>Source DNA</h1>
+  <p>Fingerprint every news source by what they cover, how they cover it, and where they focus.</p>
 </section>
 
 <!-- OVERVIEW STATS -->
 <div class="stats-row" id="statsRow">
-  <div class="stat-box"><div class="stat-val" id="statSources">--</div><div class="stat-lbl">Sources</div></div>
-  <div class="stat-box"><div class="stat-val" id="statArticles">--</div><div class="stat-lbl">Articles</div></div>
-  <div class="stat-box"><div class="stat-val" id="statAvgTone">--</div><div class="stat-lbl">Avg Tone</div></div>
-  <div class="stat-box"><div class="stat-val" id="statMostPositive">--</div><div class="stat-lbl">Most Positive</div></div>
+  <div class="stat-card">
+    <div class="stat-value t-num" id="statSources">--</div>
+    <div class="stat-label">Sources</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-value t-num" id="statArticles">--</div>
+    <div class="stat-label">Articles</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-value t-num" id="statAvgTone">--</div>
+    <div class="stat-label">Avg Tone</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-value" id="statMostPositive">--</div>
+    <div class="stat-label">Most Positive</div>
+  </div>
 </div>
 
 <!-- SORT CONTROLS -->
-<div class="controls">
-  <button class="ctrl-btn on" data-sort="articles" onclick="setSort('articles')">Most Articles</button>
-  <button class="ctrl-btn" data-sort="tone_positive" onclick="setSort('tone_positive')">Most Positive</button>
-  <button class="ctrl-btn" data-sort="tone_negative" onclick="setSort('tone_negative')">Most Negative</button>
+<div class="sort-controls">
+  <button class="btn btn-sm active" data-sort="articles" onclick="setSort('articles')">Most Articles</button>
+  <button class="btn btn-sm" data-sort="tone_positive" onclick="setSort('tone_positive')">Most Positive</button>
+  <button class="btn btn-sm" data-sort="tone_negative" onclick="setSort('tone_negative')">Most Negative</button>
 </div>
 
 <!-- SCATTER CHART -->
-<section class="chart-section">
-  <div class="chart-card">
-    <div class="chart-title">Source Landscape</div>
-    <div class="chart-sub">Bubble size = article count. X = avg tone. Y = polarity (spread between positive &amp; negative).</div>
+<section class="scatter-section">
+  <div class="scatter-card">
+    <h3 class="t-overline">Source Landscape</h3>
+    <p class="t-caption t-dim" style="margin-bottom:var(--sp-4)">Bubble size = article count. X = avg tone. Y = polarity (spread between positive &amp; negative).</p>
     <div class="chart-wrap"><canvas id="scatterChart"></canvas></div>
   </div>
 </section>
 
 <!-- SOURCE TABLE -->
-<section class="table-section">
+<section class="container" style="padding-bottom:var(--sp-7)">
   <div class="table-wrap">
-    <div class="table-header">
+    <div class="table-toolbar">
       <h3>All Sources</h3>
-      <input type="text" class="table-search" placeholder="Filter sources..." oninput="filterTable(this.value)">
+      <input type="text" class="input" style="width:220px;padding:7px 14px;font-size:0.8125rem" placeholder="Filter sources..." oninput="filterTable(this.value)">
     </div>
     <div style="overflow-x:auto">
-      <table>
+      <table class="table">
         <thead>
           <tr>
-            <th class="sorted" data-col="article_count" onclick="sortTable('article_count')">Articles <span class="arrow">▼</span></th>
-            <th data-col="source_name" onclick="sortTable('source_name')">Source</th>
-            <th data-col="avg_tone" onclick="sortTable('avg_tone')">Tone</th>
-            <th data-col="avg_polarity" onclick="sortTable('avg_polarity')">Polarity</th>
+            <th class="sortable sorted" data-col="article_count" onclick="sortTable('article_count')">Articles <span class="arrow">&#9660;</span></th>
+            <th class="sortable" data-col="source_name" onclick="sortTable('source_name')">Source</th>
+            <th class="sortable" data-col="avg_tone" onclick="sortTable('avg_tone')">Tone</th>
+            <th class="sortable" data-col="avg_polarity" onclick="sortTable('avg_polarity')">Polarity</th>
             <th>Tone Balance</th>
             <th>Top Themes</th>
           </tr>
         </thead>
         <tbody id="srcBody">
-          <tr><td colspan="6"><div class="loading">Loading<span class="spinner"></span></div></td></tr>
+          <tr><td colspan="6"><div class="loading"><span class="spinner"></span> Loading</div></td></tr>
         </tbody>
       </table>
     </div>
@@ -202,19 +317,21 @@ tbody td{padding:12px 16px;font-size:13px;white-space:nowrap}
 </section>
 
 <!-- DETAIL MODAL -->
-<div class="modal-bg" id="modalBg" onclick="closeModal()"></div>
-<div class="modal" id="modal">
-  <div class="modal-head">
-    <div style="display:flex;align-items:center"><h2 id="modalTitle"></h2><span class="domain-tag" id="modalDomain"></span></div>
-    <button class="modal-close" onclick="closeModal()">&#10005;</button>
-  </div>
-  <div class="modal-body" id="modalBody">
-    <div class="loading">Loading<span class="spinner"></span></div>
+<div class="overlay" id="modalBg" onclick="closeModal()"></div>
+<div class="overlay" id="modalWrap" onclick="closeModal()" style="pointer-events:none">
+  <div class="modal" id="modal" onclick="event.stopPropagation()" style="pointer-events:auto">
+    <div class="modal-head">
+      <div style="display:flex;align-items:center"><h2 id="modalTitle"></h2><span class="domain-tag" id="modalDomain"></span></div>
+      <button class="modal-close" onclick="closeModal()">&#10005;</button>
+    </div>
+    <div id="modalBody">
+      <div class="loading"><span class="spinner"></span> Loading</div>
+    </div>
   </div>
 </div>
 
 <script>
-const CAT_COLORS = {conflict:'#ff6b6b',economy:'#ffc844',politics:'#7b8aff',health:'#2ee8a5',environment:'#22d4e6',technology:'#a78bfa',society:'#ff9f43',general:'#8899bb'};
+const CAT_COLORS = {conflict:'#f87171',economy:'#fbbf24',politics:'#818cf8',health:'#34d399',environment:'#22d3ee',technology:'#a78bfa',society:'#fb923c',general:'#71717a'};
 
 let allSources = [];
 let currentSort = 'articles';
@@ -229,7 +346,7 @@ async function init() {
     renderScatter();
     renderTable(allSources);
   } catch (e) {
-    document.getElementById('srcBody').innerHTML = '<tr><td colspan="6" style="padding:40px;text-align:center;color:var(--text3)">Failed to load sources</td></tr>';
+    document.getElementById('srcBody').innerHTML = '<tr><td colspan="6"><div class="empty">Failed to load sources</div></td></tr>';
   }
 }
 
@@ -266,11 +383,11 @@ function renderScatter() {
         data: data,
         backgroundColor: data.map(d => {
           const c = CAT_COLORS[d.category] || CAT_COLORS.general;
-          return c + '66';
+          return c + '44';
         }),
         borderColor: data.map(d => {
           const c = CAT_COLORS[d.category] || CAT_COLORS.general;
-          return c + 'cc';
+          return c + '99';
         }),
         borderWidth: 1.5,
         hoverBorderWidth: 2.5
@@ -282,11 +399,11 @@ function renderScatter() {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: 'rgba(13,17,39,.95)',
-          borderColor: 'rgba(255,255,255,.08)',
+          backgroundColor: 'rgba(15,15,17,.95)',
+          borderColor: 'rgba(255,255,255,.06)',
           borderWidth: 1,
-          titleFont: { family: "'DM Sans'", weight: '700', size: 13 },
-          bodyFont: { family: "'DM Sans'", size: 11 },
+          titleFont: { family: "'Inter'", weight: '600', size: 13 },
+          bodyFont: { family: "'Inter'", size: 11 },
           padding: 12,
           cornerRadius: 10,
           callbacks: {
@@ -301,14 +418,14 @@ function renderScatter() {
       },
       scales: {
         x: {
-          title: { display: true, text: 'Average Tone', color: 'rgba(232,236,248,.3)', font: { family: "'DM Sans'", size: 11, weight: '600' } },
-          grid: { color: 'rgba(255,255,255,.03)' },
-          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 10 } }
+          title: { display: true, text: 'Average Tone', color: '#63636e', font: { family: "'Inter'", size: 11, weight: '500' } },
+          grid: { color: 'rgba(255,255,255,.04)' },
+          ticks: { color: '#63636e', font: { family: "'Inter'", size: 10 } }
         },
         y: {
-          title: { display: true, text: 'Polarity', color: 'rgba(232,236,248,.3)', font: { family: "'DM Sans'", size: 11, weight: '600' } },
-          grid: { color: 'rgba(255,255,255,.03)' },
-          ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 10 } }
+          title: { display: true, text: 'Polarity', color: '#63636e', font: { family: "'Inter'", size: 11, weight: '500' } },
+          grid: { color: 'rgba(255,255,255,.04)' },
+          ticks: { color: '#63636e', font: { family: "'Inter'", size: 10 } }
         }
       },
       onClick: (evt, els) => {
@@ -325,20 +442,20 @@ function renderScatter() {
 function renderTable(sources) {
   const tbody = document.getElementById('srcBody');
   if (!sources.length) {
-    tbody.innerHTML = '<tr><td colspan="6" style="padding:40px;text-align:center;color:var(--text3)">No sources found</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="6"><div class="empty">No sources found</div></td></tr>';
     return;
   }
   tbody.innerHTML = sources.map(s => {
     const posW = s.avg_positive ? Math.round(s.avg_positive / (s.avg_positive + s.avg_negative) * 100) : 50;
     const themes = (s.top_themes || []).slice(0, 3).map(t => {
       const col = CAT_COLORS[t.category] || CAT_COLORS.general;
-      return `<span class="theme-tag" style="background:${col}22;color:${col}">${humanTheme(t.theme)}</span>`;
+      return `<span class="theme-tag" style="background:${col}18;color:${col}">${humanTheme(t.theme)}</span>`;
     }).join('');
-    return `<tr onclick="openModal('${s.domain}')">
-      <td style="font-family:var(--mono);font-weight:600">${s.article_count.toLocaleString()}</td>
+    return `<tr onclick="openModal('${s.domain}')" style="cursor:pointer">
+      <td class="t-num" style="font-weight:600">${s.article_count.toLocaleString()}</td>
       <td class="src-name">${esc(s.source_name)}</td>
-      <td style="font-family:var(--mono);color:${s.avg_tone >= 0 ? 'var(--positive)' : 'var(--negative)'}">${s.avg_tone >= 0 ? '+' : ''}${s.avg_tone.toFixed(2)}</td>
-      <td style="font-family:var(--mono)">${s.avg_polarity.toFixed(2)}</td>
+      <td class="t-num" style="color:${s.avg_tone >= 0 ? 'var(--positive)' : 'var(--negative)'}">${s.avg_tone >= 0 ? '+' : ''}${s.avg_tone.toFixed(2)}</td>
+      <td class="t-num">${s.avg_polarity.toFixed(2)}</td>
       <td><div class="tone-bar"><div class="tone-pos" style="width:${posW}%"></div><div class="tone-neg" style="width:${100 - posW}%"></div></div></td>
       <td><div class="theme-tags">${themes}</div></td>
     </tr>`;
@@ -358,7 +475,7 @@ function sortTable(col) {
   document.querySelectorAll('thead th').forEach(th => {
     th.classList.toggle('sorted', th.dataset.col === col);
     const arrow = th.querySelector('.arrow');
-    if (arrow) arrow.textContent = th.dataset.col === col ? (tableSortAsc ? '▲' : '▼') : '';
+    if (arrow) arrow.textContent = th.dataset.col === col ? (tableSortAsc ? '\u25B2' : '\u25BC') : '';
   });
   const sorted = [...allSources].sort((a, b) => {
     let va = a[col], vb = b[col];
@@ -377,7 +494,7 @@ function filterTable(q) {
 // ── SORT CONTROLS ────────────────────────────────────────────────────
 function setSort(sort) {
   currentSort = sort;
-  document.querySelectorAll('.ctrl-btn').forEach(b => b.classList.toggle('on', b.dataset.sort === sort));
+  document.querySelectorAll('.sort-controls .btn').forEach(b => b.classList.toggle('active', b.dataset.sort === sort));
   fetch(`/api/sources/fingerprints?limit=100&min_articles=5&sort=${sort}`)
     .then(r => r.json())
     .then(data => {
@@ -395,18 +512,19 @@ let toneTimelineChart = null;
 let categoryChart = null;
 
 async function openModal(domain) {
-  document.getElementById('modalBg').classList.add('on');
-  document.getElementById('modal').classList.add('on');
+  document.getElementById('modalBg').classList.add('open');
+  document.getElementById('modalWrap').classList.add('open');
+  document.getElementById('modalWrap').style.pointerEvents = 'auto';
   document.getElementById('modalTitle').textContent = 'Loading...';
   document.getElementById('modalDomain').textContent = '';
-  document.getElementById('modalBody').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  document.getElementById('modalBody').innerHTML = '<div class="loading"><span class="spinner"></span> Loading</div>';
 
   try {
     const res = await fetch(`/api/sources/${encodeURIComponent(domain)}/detail`);
     const d = await res.json();
     renderModal(d);
   } catch (e) {
-    document.getElementById('modalBody').innerHTML = '<p style="color:var(--text3);text-align:center;padding:40px">Failed to load source details</p>';
+    document.getElementById('modalBody').innerHTML = '<div class="empty">Failed to load source details</div>';
   }
 }
 
@@ -418,10 +536,10 @@ function renderModal(d) {
 
   let html = `
     <div class="modal-stats">
-      <div class="m-stat"><div class="m-stat-val">${d.article_count.toLocaleString()}</div><div class="m-stat-lbl">Articles</div></div>
-      <div class="m-stat"><div class="m-stat-val" style="color:${toneColor}">${d.avg_tone >= 0 ? '+' : ''}${d.avg_tone.toFixed(2)}</div><div class="m-stat-lbl">Avg Tone</div></div>
-      <div class="m-stat"><div class="m-stat-val">${d.avg_polarity.toFixed(2)}</div><div class="m-stat-lbl">Polarity</div></div>
-      <div class="m-stat"><div class="m-stat-val">${d.countries.length}</div><div class="m-stat-lbl">Countries</div></div>
+      <div class="m-stat"><div class="m-stat-val t-num">${d.article_count.toLocaleString()}</div><div class="m-stat-lbl">Articles</div></div>
+      <div class="m-stat"><div class="m-stat-val t-num" style="color:${toneColor}">${d.avg_tone >= 0 ? '+' : ''}${d.avg_tone.toFixed(2)}</div><div class="m-stat-lbl">Avg Tone</div></div>
+      <div class="m-stat"><div class="m-stat-val t-num">${d.avg_polarity.toFixed(2)}</div><div class="m-stat-lbl">Polarity</div></div>
+      <div class="m-stat"><div class="m-stat-val t-num">${d.countries.length}</div><div class="m-stat-lbl">Countries</div></div>
     </div>
 
     <div class="modal-grid">
@@ -435,12 +553,12 @@ function renderModal(d) {
       </div>
     </div>
 
-    <div class="modal-chart-card" style="margin-bottom:24px">
+    <div class="modal-chart-card" style="margin-bottom:var(--sp-5)">
       <h4>Top Themes</h4>
       <div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px">
         ${d.themes.slice(0, 15).map(t => {
           const col = CAT_COLORS[t.category] || CAT_COLORS.general;
-          return `<span class="theme-tag" style="background:${col}22;color:${col};padding:4px 10px;font-size:11px">${humanTheme(t.theme)} <span style="opacity:.5;margin-left:2px">${t.count}</span></span>`;
+          return `<span class="theme-tag" style="background:${col}18;color:${col};padding:4px 10px;font-size:0.6875rem">${humanTheme(t.theme)} <span style="opacity:.5;margin-left:2px">${t.count}</span></span>`;
         }).join('')}
       </div>
     </div>
@@ -450,7 +568,7 @@ function renderModal(d) {
       <div class="recent-list" style="margin-top:12px">
         ${d.recent_articles.map(a => {
           const tone = a.tone_score;
-          const col = tone != null ? (tone >= 0 ? 'var(--positive)' : 'var(--negative)') : 'var(--text3)';
+          const col = tone != null ? (tone >= 0 ? 'var(--positive)' : 'var(--negative)') : 'var(--text-3)';
           const ts = a.gdelt_timestamp ? new Date(a.gdelt_timestamp).toLocaleDateString('en-US', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : '';
           return `<a href="${esc(a.url)}" target="_blank" class="recent-item" style="text-decoration:none;color:var(--text)">
             <div class="recent-title">${esc(a.title)}</div>
@@ -489,8 +607,8 @@ function renderToneTimeline(timeline) {
       }),
       datasets: [{
         data: timeline.map(t => t.avg_tone),
-        borderColor: '#2ee8a5',
-        backgroundColor: 'rgba(46,232,165,.1)',
+        borderColor: '#8b8bf5',
+        backgroundColor: 'rgba(139,139,245,.08)',
         fill: true,
         tension: 0.4,
         pointRadius: 2,
@@ -502,11 +620,11 @@ function renderToneTimeline(timeline) {
       responsive: true,
       maintainAspectRatio: false,
       plugins: { legend: { display: false }, tooltip: {
-        backgroundColor: 'rgba(13,17,39,.95)',
-        borderColor: 'rgba(255,255,255,.08)',
+        backgroundColor: 'rgba(15,15,17,.95)',
+        borderColor: 'rgba(255,255,255,.06)',
         borderWidth: 1,
-        titleFont: { family: "'DM Sans'", size: 11 },
-        bodyFont: { family: "'JetBrains Mono'", size: 11 },
+        titleFont: { family: "'Inter'", size: 11 },
+        bodyFont: { family: "'Inter'", size: 11 },
         padding: 10,
         cornerRadius: 8,
         callbacks: {
@@ -514,8 +632,8 @@ function renderToneTimeline(timeline) {
         }
       }},
       scales: {
-        x: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { size: 9 }, maxTicksLimit: 8 } },
-        y: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 } } }
+        x: { grid: { color: 'rgba(255,255,255,.04)' }, ticks: { color: '#63636e', font: { family: "'Inter'", size: 9 }, maxTicksLimit: 8 } },
+        y: { grid: { color: 'rgba(255,255,255,.04)' }, ticks: { color: '#63636e', font: { family: "'Inter'", size: 9 } } }
       }
     }
   });
@@ -532,7 +650,7 @@ function renderCategoryChart(categories) {
       labels: categories.map(c => c.category.charAt(0).toUpperCase() + c.category.slice(1)),
       datasets: [{
         data: categories.map(c => c.pct),
-        backgroundColor: categories.map(c => (CAT_COLORS[c.category] || CAT_COLORS.general) + '88'),
+        backgroundColor: categories.map(c => (CAT_COLORS[c.category] || CAT_COLORS.general) + '66'),
         borderColor: categories.map(c => (CAT_COLORS[c.category] || CAT_COLORS.general)),
         borderWidth: 1.5
       }]
@@ -544,11 +662,11 @@ function renderCategoryChart(categories) {
       plugins: {
         legend: {
           position: 'right',
-          labels: { color: 'rgba(232,236,248,.55)', font: { family: "'DM Sans'", size: 10, weight: '600' }, padding: 8, boxWidth: 10, boxHeight: 10, borderRadius: 3 }
+          labels: { color: '#a1a1aa', font: { family: "'Inter'", size: 10, weight: '500' }, padding: 8, boxWidth: 10, boxHeight: 10, borderRadius: 3 }
         },
         tooltip: {
-          backgroundColor: 'rgba(13,17,39,.95)',
-          bodyFont: { family: "'DM Sans'", size: 11 },
+          backgroundColor: 'rgba(15,15,17,.95)',
+          bodyFont: { family: "'Inter'", size: 11 },
           padding: 10,
           cornerRadius: 8,
           callbacks: { label: ctx => ` ${ctx.label}: ${ctx.raw}%` }
@@ -559,8 +677,9 @@ function renderCategoryChart(categories) {
 }
 
 function closeModal() {
-  document.getElementById('modalBg').classList.remove('on');
-  document.getElementById('modal').classList.remove('on');
+  document.getElementById('modalBg').classList.remove('open');
+  document.getElementById('modalWrap').classList.remove('open');
+  document.getElementById('modalWrap').style.pointerEvents = 'none';
   if (toneTimelineChart) { toneTimelineChart.destroy(); toneTimelineChart = null; }
   if (categoryChart) { categoryChart.destroy(); categoryChart = null; }
 }

--- a/src/gdelt_event_pipeline/api/static/velocity.html
+++ b/src/gdelt_event_pipeline/api/static/velocity.html
@@ -3,116 +3,297 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="theme-color" content="#0d1127">
-<title>Topic Velocity — Pulse</title>
+<meta name="theme-color" content="#09090b">
+<title>Topic Velocity — GDELT Pulse</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;450;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/pulse.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <style>
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --bg:#0d1127;
-  --bg2:#131838;
-  --card:rgba(20,26,56,.82);
-  --card-sh:0 4px 24px rgba(0,0,0,.25),0 0 0 1px rgba(255,255,255,.04);
-  --text:#e8ecf8;
-  --text2:rgba(232,236,248,.55);
-  --text3:rgba(232,236,248,.3);
-  --accent:#2ee8a5;
-  --accent-soft:rgba(46,232,165,.1);
-  --rising:#2ee8a5;--declining:#ff6b6b;
-  --conflict:#ff6b6b;--economy:#ffc844;--politics:#7b8aff;
-  --health:#2ee8a5;--environment:#22d4e6;--technology:#a78bfa;
-  --society:#ff9f43;--general:#8899bb;
-  --sans:'DM Sans',-apple-system,BlinkMacSystemFont,sans-serif;
-  --mono:'JetBrains Mono',monospace;
-  --r:16px;
+/* ── Velocity-specific styles ─────────────────────────── */
+body { padding-top: 56px; }
+
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: var(--sp-2);
+  padding: 0 var(--sp-5) var(--sp-6);
+  flex-wrap: wrap;
 }
-body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100dvh;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-a{color:var(--accent);text-decoration:none}
 
-.bar{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:16px 28px;background:rgba(13,17,39,.85);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.04)}
-.brand{display:flex;align-items:center;gap:8px;font-size:18px;font-weight:700;color:var(--text);letter-spacing:-.02em;cursor:pointer}
-.brand i{width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bPulse 2s ease-in-out infinite}
-@keyframes bPulse{0%,100%{box-shadow:0 0 0 0 rgba(46,232,165,.4)}50%{box-shadow:0 0 0 7px rgba(46,232,165,0)}}
-.bar-right{display:flex;align-items:center;gap:12px}
-.bar-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text2);padding:7px 16px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.08);background:none;transition:all .2s}
-.bar-btn:hover{color:var(--text);border-color:rgba(255,255,255,.15);background:rgba(255,255,255,.03)}
+.ctrl-btn {
+  font-family: var(--font);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-3);
+  padding: 7px 18px;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: none;
+  transition: all var(--duration) var(--ease);
+}
 
-.hero{text-align:center;padding:48px 28px 24px}
-.hero h1{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1.1;margin-bottom:10px}
-.hero h1 span{color:var(--accent)}
-.hero p{font-size:14px;color:var(--text2);max-width:520px;margin:0 auto;line-height:1.6}
+.ctrl-btn:hover {
+  color: var(--text-2);
+  border-color: var(--border-hover);
+}
 
-.controls{display:flex;justify-content:center;gap:8px;padding:0 28px 28px;flex-wrap:wrap}
-.ctrl-btn{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--text3);padding:7px 18px;border-radius:100px;cursor:pointer;border:1px solid rgba(255,255,255,.06);background:none;transition:all .25s}
-.ctrl-btn:hover{color:var(--text2);border-color:rgba(255,255,255,.12)}
-.ctrl-btn.on{color:var(--text);background:var(--accent-soft);border-color:var(--accent)}
+.ctrl-btn.on {
+  color: var(--text);
+  background: var(--surface-2);
+  border-color: var(--border-active);
+}
 
-.content{max-width:1100px;margin:0 auto;padding:0 28px 40px}
-.two-col{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-bottom:24px}
-@media(max-width:768px){.two-col{grid-template-columns:1fr}}
+/* ── Panel styling ────────────────────────────────────── */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
 
-.panel{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);overflow:hidden;box-shadow:var(--card-sh)}
-.panel-head{display:flex;align-items:center;gap:8px;padding:16px 20px 12px;border-bottom:1px solid rgba(255,255,255,.04)}
-.panel-head h3{font-size:14px;font-weight:700}
-.panel-head .badge{font-size:10px;font-weight:700;padding:3px 10px;border-radius:100px;font-family:var(--mono)}
-.badge-rising{background:rgba(46,232,165,.12);color:var(--rising)}
-.badge-declining{background:rgba(255,107,107,.12);color:var(--declining)}
+.panel-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-4) var(--sp-5) var(--sp-3);
+  border-bottom: 1px solid var(--border);
+}
 
-.topic-row{display:flex;align-items:center;gap:12px;padding:10px 20px;border-bottom:1px solid rgba(255,255,255,.02);cursor:pointer;transition:background .15s}
-.topic-row:hover{background:rgba(46,232,165,.03)}
-.topic-row.active{background:rgba(46,232,165,.06);border-left:3px solid var(--accent)}
+.panel-head h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
 
-.t-rank{font-size:11px;font-family:var(--mono);color:var(--text3);width:24px;text-align:center;flex-shrink:0}
-.t-info{flex:1;min-width:0}
-.t-name{font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.t-cat{font-size:9px;font-weight:600;padding:2px 7px;border-radius:100px;margin-top:2px;display:inline-block}
-.t-stats{display:flex;gap:8px;align-items:center;flex-shrink:0}
-.t-count{font-size:11px;font-family:var(--mono);color:var(--text3)}
-.t-vel{font-size:12px;font-weight:700;font-family:var(--mono);min-width:60px;text-align:right}
-.t-vel.up{color:var(--rising)}
-.t-vel.down{color:var(--declining)}
-.t-bar-wrap{width:60px;height:6px;background:rgba(255,255,255,.04);border-radius:3px;overflow:hidden}
-.t-bar{height:100%;border-radius:3px}
+.panel-head .badge {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-variant-numeric: tabular-nums;
+}
 
-/* ── DETAIL PANEL ────────────── */
-.detail-section{margin-top:24px}
-.detail-card{background:var(--card);border:1px solid rgba(255,255,255,.05);border-radius:var(--r);padding:24px;box-shadow:var(--card-sh)}
-.detail-card h3{font-size:16px;font-weight:700;margin-bottom:4px}
-.detail-card .detail-sub{font-size:11px;color:var(--text3);margin-bottom:20px}
-.chart-wrap{position:relative;height:260px;margin-bottom:20px}
+.badge-rising {
+  background: rgba(52, 211, 153, 0.08);
+  color: var(--positive);
+  border: 1px solid rgba(52, 211, 153, 0.12);
+}
 
-.detail-stats{display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap}
-.d-stat{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);border-radius:12px;padding:14px 18px;text-align:center;flex:1;min-width:100px}
-.d-stat-val{font-size:22px;font-weight:700;font-family:var(--mono)}
-.d-stat-lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-top:2px}
+.badge-declining {
+  background: rgba(248, 113, 113, 0.08);
+  color: var(--negative);
+  border: 1px solid rgba(248, 113, 113, 0.12);
+}
 
-.articles-list{display:flex;flex-direction:column;gap:8px}
-.articles-list h4{font-size:13px;font-weight:700;margin-bottom:8px}
-.art-item{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:12px;padding:12px 16px;transition:background .15s}
-.art-item:hover{background:rgba(255,255,255,.04)}
-.art-item a{color:var(--text);font-size:13px;font-weight:600;line-height:1.4;transition:color .15s}
-.art-item a:hover{color:var(--accent)}
-.art-meta{font-size:10px;color:var(--text3);margin-top:4px;display:flex;gap:12px}
+/* ── Topic rows ───────────────────────────────────────── */
+.topic-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: 10px var(--sp-5);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background var(--duration) var(--ease);
+}
 
-.loading{display:flex;align-items:center;justify-content:center;padding:60px;color:var(--text3);gap:10px;font-size:13px}
-.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.08);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite}
-@keyframes spin{to{transform:rotate(360deg)}}
+.topic-row:last-child { border-bottom: none; }
+.topic-row:hover { background: var(--surface-2); }
+
+.topic-row.active {
+  background: var(--surface-2);
+  border-left: 3px solid var(--text-2);
+}
+
+.t-rank {
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+  width: 24px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.t-info { flex: 1; min-width: 0; }
+
+.t-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.01em;
+}
+
+.t-cat {
+  font-size: 0.5625rem;
+  font-weight: 500;
+  padding: 2px 7px;
+  border-radius: var(--radius-full);
+  margin-top: 2px;
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.t-stats {
+  display: flex;
+  gap: var(--sp-2);
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.t-count {
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+}
+
+.t-vel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  min-width: 60px;
+  text-align: right;
+}
+
+.t-vel.up { color: var(--positive); }
+.t-vel.down { color: var(--negative); }
+
+.t-bar-wrap {
+  width: 60px;
+  height: 4px;
+  background: var(--surface-3);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.t-bar { height: 100%; border-radius: 2px; }
+
+/* ── Detail section ───────────────────────────────────── */
+.detail-section { margin-top: var(--sp-5); }
+
+.detail-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+}
+
+.detail-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin-bottom: 2px;
+}
+
+.detail-card .detail-sub {
+  font-size: 0.6875rem;
+  color: var(--text-3);
+  margin-bottom: var(--sp-5);
+}
+
+.chart-wrap {
+  position: relative;
+  height: 260px;
+  margin-bottom: var(--sp-5);
+}
+
+.detail-stats {
+  display: flex;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-5);
+  flex-wrap: wrap;
+}
+
+.d-stat {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  text-align: center;
+  flex: 1;
+  min-width: 100px;
+}
+
+.d-stat-val {
+  font-size: 1.375rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.d-stat-lbl {
+  font-size: 0.5625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  margin-top: 2px;
+}
+
+/* ── Articles list ────────────────────────────────────── */
+.articles-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.articles-list h4 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: var(--sp-2);
+  letter-spacing: -0.01em;
+}
+
+.art-item {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  transition: border-color var(--duration) var(--ease);
+}
+
+.art-item:hover { border-color: var(--border-hover); }
+
+.art-item a {
+  color: var(--text);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.4;
+  transition: color var(--duration);
+}
+
+.art-item a:hover { color: var(--text-2); }
+
+.art-meta {
+  font-size: 0.625rem;
+  color: var(--text-3);
+  margin-top: 4px;
+  display: flex;
+  gap: var(--sp-3);
+}
+
+/* ── Responsive ───────────────────────────────────────── */
+@media (max-width: 768px) {
+  .detail-stats { gap: var(--sp-2); }
+  .d-stat { min-width: 80px; padding: 10px 12px; }
+}
 </style>
 </head>
 <body>
 
-<header class="bar">
-  <div class="brand" onclick="location.href='/'"><i></i> Pulse</div>
-  <div class="bar-right">
-    <button class="bar-btn" onclick="location.href='/globe'">Globe</button>
-    <button class="bar-btn" onclick="location.href='/'">Home</button>
-  </div>
-</header>
+<nav class="topbar">
+  <a class="topbar-back" href="/">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+    GDELT Pulse
+  </a>
+</nav>
 
-<section class="hero">
-  <h1>Topic <span>Velocity</span></h1>
+<section class="page-intro">
+  <h1>Topic Velocity</h1>
   <p>See which topics are accelerating or fading in real-time. Track how the media agenda shifts hour by hour.</p>
 </section>
 
@@ -123,15 +304,15 @@ a{color:var(--accent);text-decoration:none}
   <button class="ctrl-btn" data-hours="168" onclick="setWindow(168)">7 Days</button>
 </div>
 
-<div class="content">
+<div class="container">
   <div class="two-col" id="panels">
     <div class="panel" id="risingPanel">
       <div class="panel-head"><h3>Rising</h3><span class="badge badge-rising">Accelerating</span></div>
-      <div id="risingList"><div class="loading">Loading<span class="spinner"></span></div></div>
+      <div id="risingList"><div class="loading"><span class="spinner"></span>Loading</div></div>
     </div>
     <div class="panel" id="decliningPanel">
       <div class="panel-head"><h3>Declining</h3><span class="badge badge-declining">Decelerating</span></div>
-      <div id="decliningList"><div class="loading">Loading<span class="spinner"></span></div></div>
+      <div id="decliningList"><div class="loading"><span class="spinner"></span>Loading</div></div>
     </div>
   </div>
 
@@ -147,7 +328,8 @@ a{color:var(--accent);text-decoration:none}
 </div>
 
 <script>
-const CAT_COLORS = {conflict:'#ff6b6b',economy:'#ffc844',politics:'#7b8aff',health:'#2ee8a5',environment:'#22d4e6',technology:'#a78bfa',society:'#ff9f43',general:'#8899bb'};
+const CAT_COLORS = {conflict:'var(--cat-conflict)',economy:'var(--cat-economy)',politics:'var(--cat-politics)',health:'var(--cat-health)',environment:'var(--cat-environment)',technology:'var(--cat-technology)',society:'var(--cat-society)',general:'var(--cat-general)'};
+const CAT_HEX = {conflict:'#f87171',economy:'#fbbf24',politics:'#818cf8',health:'#34d399',environment:'#22d3ee',technology:'#a78bfa',society:'#fb923c',general:'#71717a'};
 
 let currentWindow = 48;
 let allData = null;
@@ -164,7 +346,7 @@ async function loadTopics() {
     allData = await res.json();
     renderLists();
   } catch (e) {
-    document.getElementById('risingList').innerHTML = '<div style="padding:40px;text-align:center;color:var(--text3)">Failed to load</div>';
+    document.getElementById('risingList').innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-3)">Failed to load</div>';
     document.getElementById('decliningList').innerHTML = '';
   }
 }
@@ -181,17 +363,17 @@ function renderLists() {
 }
 
 function topicRow(t, rank, maxTotal, isRising) {
-  const col = CAT_COLORS[t.category] || CAT_COLORS.general;
+  const col = CAT_HEX[t.category] || CAT_HEX.general;
   const velStr = t.velocity_pct >= 0 ? `+${t.velocity_pct}%` : `${t.velocity_pct}%`;
   const barPct = Math.round(t.total_count / maxTotal * 100);
-  const barCol = isRising ? 'var(--rising)' : 'var(--declining)';
+  const barCol = isRising ? 'var(--positive)' : 'var(--negative)';
   const active = selectedTheme === t.theme ? 'active' : '';
 
   return `<div class="topic-row ${active}" onclick="selectTopic('${esc(t.theme)}')">
     <span class="t-rank">${rank}</span>
     <div class="t-info">
       <div class="t-name">${humanTheme(t.theme)}</div>
-      <span class="t-cat" style="background:${col}22;color:${col}">${t.category}</span>
+      <span class="t-cat" style="background:${col}14;color:${col}">${t.category}</span>
     </div>
     <div class="t-stats">
       <span class="t-count">${t.total_count}</span>
@@ -206,8 +388,8 @@ function setWindow(hours) {
   document.querySelectorAll('.ctrl-btn').forEach(b => b.classList.toggle('on', parseInt(b.dataset.hours) === hours));
   selectedTheme = null;
   document.getElementById('detailSection').style.display = 'none';
-  document.getElementById('risingList').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
-  document.getElementById('decliningList').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  document.getElementById('risingList').innerHTML = '<div class="loading"><span class="spinner"></span>Loading</div>';
+  document.getElementById('decliningList').innerHTML = '<div class="loading"><span class="spinner"></span>Loading</div>';
   loadTopics();
 }
 
@@ -219,7 +401,7 @@ async function selectTopic(theme) {
   section.style.display = 'block';
   document.getElementById('detailTitle').textContent = humanTheme(theme);
   document.getElementById('detailSub').textContent = `Theme: ${theme}`;
-  document.getElementById('detailStats').innerHTML = '<div class="loading">Loading<span class="spinner"></span></div>';
+  document.getElementById('detailStats').innerHTML = '<div class="loading"><span class="spinner"></span>Loading</div>';
   document.getElementById('detailArticles').innerHTML = '';
 
   try {
@@ -227,7 +409,7 @@ async function selectTopic(theme) {
     const d = await res.json();
     renderDetail(d);
   } catch (e) {
-    document.getElementById('detailStats').innerHTML = '<div style="color:var(--text3)">Failed to load</div>';
+    document.getElementById('detailStats').innerHTML = '<div style="color:var(--text-3)">Failed to load</div>';
   }
 
   section.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -240,11 +422,11 @@ function renderDetail(d) {
     ? (avgTone.reduce((a, b) => a + b.avg_tone * b.count, 0) / avgTone.reduce((a, b) => a + b.count, 0))
     : 0;
   const peakHour = d.timeline.reduce((a, b) => b.count > a.count ? b : a, { count: 0 });
-  const col = CAT_COLORS[d.category] || CAT_COLORS.general;
+  const col = CAT_HEX[d.category] || CAT_HEX.general;
 
   document.getElementById('detailStats').innerHTML = `
     <div class="d-stat"><div class="d-stat-val">${totalArticles}</div><div class="d-stat-lbl">Total Articles</div></div>
-    <div class="d-stat"><div class="d-stat-val" style="color:${meanTone >= 0 ? 'var(--rising)' : 'var(--declining)'}">${meanTone >= 0 ? '+' : ''}${meanTone.toFixed(2)}</div><div class="d-stat-lbl">Avg Tone</div></div>
+    <div class="d-stat"><div class="d-stat-val" style="color:${meanTone >= 0 ? 'var(--positive)' : 'var(--negative)'}">${meanTone >= 0 ? '+' : ''}${meanTone.toFixed(2)}</div><div class="d-stat-lbl">Avg Tone</div></div>
     <div class="d-stat"><div class="d-stat-val">${peakHour.count}</div><div class="d-stat-lbl">Peak Hour</div></div>
     <div class="d-stat"><div class="d-stat-val" style="color:${col}">${d.category}</div><div class="d-stat-lbl">Category</div></div>
   `;
@@ -264,7 +446,7 @@ function renderDetail(d) {
         label: 'Articles',
         data: d.timeline.map(t => t.count),
         borderColor: col,
-        backgroundColor: col + '22',
+        backgroundColor: col + '14',
         fill: true,
         tension: 0.3,
         pointRadius: 1.5,
@@ -278,18 +460,21 @@ function renderDetail(d) {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: 'rgba(13,17,39,.95)',
-          borderColor: 'rgba(255,255,255,.08)',
+          backgroundColor: '#141416',
+          borderColor: 'rgba(255,255,255,0.06)',
           borderWidth: 1,
-          bodyFont: { family: "'JetBrains Mono'", size: 11 },
+          titleFont: { family: "'Inter'", size: 11 },
+          bodyFont: { family: "'Inter'", size: 11 },
           padding: 10,
           cornerRadius: 8,
+          titleColor: '#a1a1aa',
+          bodyColor: '#fafafa',
           callbacks: { label: ctx => `${ctx.raw} articles` }
         }
       },
       scales: {
-        x: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { size: 9 }, maxTicksLimit: 10, maxRotation: 45 } },
-        y: { grid: { color: 'rgba(255,255,255,.03)' }, ticks: { color: 'rgba(232,236,248,.3)', font: { family: "'JetBrains Mono'", size: 9 } }, beginAtZero: true }
+        x: { grid: { color: 'rgba(255,255,255,0.03)' }, ticks: { color: '#63636e', font: { family: "'Inter'", size: 9 }, maxTicksLimit: 10, maxRotation: 45 } },
+        y: { grid: { color: 'rgba(255,255,255,0.03)' }, ticks: { color: '#63636e', font: { family: "'Inter'", size: 9 } }, beginAtZero: true }
       }
     }
   });
@@ -299,13 +484,13 @@ function renderDetail(d) {
     document.getElementById('detailArticles').innerHTML = `<h4>Recent Articles</h4>` +
       d.recent_articles.map(a => {
         const ts = a.gdelt_timestamp ? new Date(a.gdelt_timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
-        const toneCol = a.tone_score != null ? (a.tone_score >= 0 ? 'var(--rising)' : 'var(--declining)') : 'var(--text3)';
+        const toneCol = a.tone_score != null ? (a.tone_score >= 0 ? 'var(--positive)' : 'var(--negative)') : 'var(--text-3)';
         return `<div class="art-item">
           <a href="${esc(a.url)}" target="_blank">${esc(a.title)}</a>
           <div class="art-meta">
             <span>${esc(a.domain)}</span>
             <span>${ts}</span>
-            ${a.tone_score != null ? `<span style="color:${toneCol};font-family:var(--mono);font-weight:700">${a.tone_score >= 0 ? '+' : ''}${a.tone_score.toFixed(1)}</span>` : ''}
+            ${a.tone_score != null ? `<span style="color:${toneCol};font-variant-numeric:tabular-nums;font-weight:600">${a.tone_score >= 0 ? '+' : ''}${a.tone_score.toFixed(1)}</span>` : ''}
           </div>
         </div>`;
       }).join('');


### PR DESCRIPTION
## Summary

This branch adds all analytical views to GDELT Pulse and redesigns the entire frontend.

### Analysis Features
- **Geopolitical Gravity** — Country co-mention force graph (D3.js) with dynamic density slider, sidebar detail panel, and tone-colored nodes
- **Attention Asymmetry** — Treemap + scatter plot showing per-country coverage volume vs crisis ratio, with overcovered/underreported story detection
- **Polarization** — Tone distribution analysis across clusters with std-dev-based polarization scoring
- **Propagation** — Timeline visualization of how stories spread across sources over time
- **Velocity** — Rising/declining cluster detection with time-window filtering
- **Sources** — Source reliability analysis with bubble chart and detail modals
- **Globe** — 3D globe with live/rising/silent cluster modes, using DB reference time instead of `now()`

### Website Redesign
- Shared `pulse.css` design system: dark theme (`#09090b`), Inter font, CSS custom properties, reusable components
- All 8 HTML pages rewritten with premium editorial aesthetic inspired by Bending Spoons
- Consistent topbar, typography, card, table, and modal patterns across all views

### Bug Fixes
- Globe endpoint: use `MAX(gdelt_timestamp)` instead of `now()` for static DB snapshots
- Asymmetry: use `COUNT(DISTINCT)` for total articles (was double-counting multi-country articles)
- Gravity: dynamic slider max from API response so graph always has at least one edge
- Normalize: include `raw_payload` in output to fix failing test

## Test plan
- [ ] Run `uvicorn` locally and verify all 8 pages load and render correctly
- [ ] Globe: check live/rising/silent modes return data
- [ ] Gravity: slide density to max — graph should still show at least one edge
- [ ] Asymmetry: verify total articles count matches actual DB count (~250k)
- [ ] Check all pages link to `/static/pulse.css` and styles apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)