### PR TITLE
perf: batch remote-DB writes and reads across the pipeline

### DIFF
--- a/src/gdelt_event_pipeline/clustering/assign.py
+++ b/src/gdelt_event_pipeline/clustering/assign.py
@@ -20,7 +20,7 @@ from gdelt_event_pipeline.storage.clusters import (
     assign_article_to_cluster,
     create_cluster,
     find_nearest_cluster,
-    get_cluster_entity_sample,
+    get_cluster_entity_samples,
     update_cluster_centroid,
 )
 
@@ -63,15 +63,19 @@ def assign_article(
     # Stage 1: find top candidates by cosine similarity (within temporal window)
     candidates = find_nearest_cluster(embedding, limit=N_CANDIDATES, max_age_hours=max_age_hours)
 
-    # Stage 2: score each candidate with entity overlap
+    # Stage 2: score each candidate with entity overlap.  One query fetches
+    # entity samples for all candidates — cheaper than N per-candidate round
+    # trips against a remote DB.
+    candidate_ids = [str(c["id"]) for c in candidates]
+    entity_samples = get_cluster_entity_samples(candidate_ids, limit=5)
+
     best_match = None
     best_score = -1.0
 
     for candidate in candidates:
         cosine_sim = 1.0 - candidate["cosine_distance"]
 
-        # Fetch entities from the cluster's recent articles
-        sample = get_cluster_entity_sample(str(candidate["id"]), limit=5)
+        sample = entity_samples.get(str(candidate["id"]), [])
         cluster_entities = merge_entity_sets([extract_entity_sets(row) for row in sample])
 
         entity_overlap = compute_entity_overlap(article_entities, cluster_entities)

--- a/src/gdelt_event_pipeline/embeddings/pipeline.py
+++ b/src/gdelt_event_pipeline/embeddings/pipeline.py
@@ -10,7 +10,7 @@ from gdelt_event_pipeline.embeddings.embed import embed_texts
 from gdelt_event_pipeline.embeddings.text import compose_embedding_text
 from gdelt_event_pipeline.storage.articles import (
     get_unembedded_articles,
-    update_article_embedding,
+    update_article_embeddings,
 )
 
 logger = logging.getLogger(__name__)
@@ -80,18 +80,18 @@ def run_embedding(
         batch_size=settings.batch_size,
     )
 
-    # Store results
-    for article, vector in zip(valid_articles, vectors, strict=True):
-        try:
-            update_article_embedding(
-                str(article["id"]),
-                vector,
-                settings.model_name,
-            )
-            result.articles_embedded += 1
-        except Exception:
-            logger.exception("Failed to store embedding for article %s", article.get("id"))
-            result.articles_failed += 1
+    # Store results in one batched UPDATE (chunked internally) — avoids N
+    # per-row round trips that dominate cycle time on a remote Postgres.
+    updates = [
+        (str(article["id"]), list(vector))
+        for article, vector in zip(valid_articles, vectors, strict=True)
+    ]
+    try:
+        written = update_article_embeddings(updates, settings.model_name)
+        result.articles_embedded = written
+    except Exception:
+        logger.exception("Failed to store embeddings (%d articles)", len(updates))
+        result.articles_failed = len(updates)
 
     logger.info(
         "Embedding complete: fetched=%d embedded=%d skipped=%d failed=%d",

--- a/src/gdelt_event_pipeline/ingestion/pipeline.py
+++ b/src/gdelt_event_pipeline/ingestion/pipeline.py
@@ -13,7 +13,7 @@ from gdelt_event_pipeline.normalization.normalize import normalize_row
 from gdelt_event_pipeline.storage.articles import (
     get_untitled_articles,
     increment_scrape_attempts,
-    update_article_title,
+    update_article_titles,
     upsert_articles,
 )
 from gdelt_event_pipeline.storage.pipeline_state import (
@@ -129,7 +129,7 @@ def run_title_scraping(
     *,
     batch_size: int | None = None,
     timeout: int = 10,
-    max_workers: int = 8,
+    max_workers: int = 32,
 ) -> tuple[int, int]:
     """Scrape titles for articles that don't have one yet.
 
@@ -149,8 +149,9 @@ def run_title_scraping(
     all_ids = [str(a["id"]) for a in articles]
     increment_scrape_attempts(all_ids)
 
-    for article_id, title in titles.items():
-        update_article_title(article_id, title)
+    # Persist successful titles in one batched UPDATE — otherwise each write
+    # pays a round trip to Postgres, which dominates cycle time on remote DBs.
+    update_article_titles(titles)
 
     logger.info("Updated %d/%d article titles", len(titles), len(articles))
     return len(articles), len(titles)

--- a/src/gdelt_event_pipeline/ingestion/pipeline.py
+++ b/src/gdelt_event_pipeline/ingestion/pipeline.py
@@ -14,13 +14,15 @@ from gdelt_event_pipeline.storage.articles import (
     get_untitled_articles,
     increment_scrape_attempts,
     update_article_title,
-    upsert_article,
+    upsert_articles,
 )
 from gdelt_event_pipeline.storage.pipeline_state import (
     update_pipeline_state,
 )
 
 logger = logging.getLogger(__name__)
+
+UPSERT_CHUNK_SIZE = 500
 
 
 @dataclass
@@ -45,8 +47,8 @@ def run_ingestion(
 
     1. Resolve the GKG file URL (latest or explicit)
     2. Download and parse the CSV rows
-    3. Normalize each row
-    4. Upsert into the database (unless dry_run)
+    3. Normalize each row and deduplicate by canonical URL
+    4. Batch-upsert into the database in chunks (unless dry_run)
     5. Update pipeline_state checkpoint
 
     Returns an IngestionResult with counts.
@@ -62,10 +64,10 @@ def run_ingestion(
     result.rows_fetched = len(rows)
     logger.info("Fetched %d rows", result.rows_fetched)
 
-    # 3-4. Normalize and upsert
+    # 3. Normalize + deduplicate in memory.  Multi-row INSERTs can't touch the
+    # same ON CONFLICT target twice, so we have to dedupe before the DB call.
     seen_canonical_urls: set[str] = set()
-    last_timestamp = None
-    last_record_id = None
+    articles_to_upsert: list[dict] = []
 
     for row in rows:
         article = normalize_row(row)
@@ -75,29 +77,31 @@ def run_ingestion(
 
         result.rows_normalized += 1
 
-        # Deduplicate within this batch
-        canonical = article[
-            "canonical_url"
-        ]  # it is the normalized URL, so should be consistent across duplicates
+        canonical = article["canonical_url"]
         if canonical in seen_canonical_urls:
             result.duplicate_urls += 1
             continue
         seen_canonical_urls.add(canonical)
 
-        if dry_run:
-            result.rows_upserted += 1
-            continue
+        articles_to_upsert.append(article)
 
-        try:
-            upsert_article(article)
-            result.rows_upserted += 1
+    # 4. Batch upsert
+    last_timestamp = None
+    last_record_id = None
 
-            # Track latest for checkpoint
-            last_timestamp = article["gdelt_timestamp"]
-            last_record_id = article["gkg_record_id"]
-        except Exception:
-            logger.exception("Failed to upsert article %s", article.get("canonical_url"))
-            result.rows_failed += 1
+    if dry_run:
+        result.rows_upserted = len(articles_to_upsert)
+    elif articles_to_upsert:
+        for start in range(0, len(articles_to_upsert), UPSERT_CHUNK_SIZE):
+            chunk = articles_to_upsert[start : start + UPSERT_CHUNK_SIZE]
+            try:
+                written = upsert_articles(chunk, chunk_size=UPSERT_CHUNK_SIZE)
+                result.rows_upserted += written
+                last_timestamp = chunk[-1]["gdelt_timestamp"]
+                last_record_id = chunk[-1]["gkg_record_id"]
+            except Exception:
+                logger.exception("Failed to upsert chunk of %d articles", len(chunk))
+                result.rows_failed += len(chunk)
 
     # 5. Update checkpoint
     if not dry_run and last_timestamp is not None:

--- a/src/gdelt_event_pipeline/storage/articles.py
+++ b/src/gdelt_event_pipeline/storage/articles.py
@@ -9,74 +9,122 @@ from psycopg.rows import dict_row
 
 from gdelt_event_pipeline.storage.database import get_pool
 
+# 14 article fields + first_seen_at/last_seen_at reusing gdelt_timestamp = 16 placeholders per row
+_UPSERT_COLUMNS = (
+    "gkg_record_id",
+    "gdelt_timestamp",
+    "url",
+    "canonical_url",
+    "domain",
+    "source_common_name",
+    "canonical_source",
+    "title",
+    "themes",
+    "locations",
+    "organizations",
+    "persons",
+    "all_names",
+    "tone",
+)
+_ROW_PLACEHOLDERS = "(" + ", ".join(["%s"] * (len(_UPSERT_COLUMNS) + 2)) + ")"
 
-def upsert_article(article: dict[str, Any]) -> dict[str, Any]:
-    """Insert or update an article record.
+_UPSERT_CONFLICT_CLAUSE = """
+ON CONFLICT (canonical_url) DO UPDATE SET
+    themes         = CASE
+                        WHEN COALESCE(jsonb_array_length(EXCLUDED.themes), 0)
+                           > COALESCE(jsonb_array_length(articles.themes), 0)
+                        THEN EXCLUDED.themes
+                        ELSE articles.themes
+                     END,
+    locations      = CASE
+                        WHEN COALESCE(jsonb_array_length(EXCLUDED.locations), 0)
+                           > COALESCE(jsonb_array_length(articles.locations), 0)
+                        THEN EXCLUDED.locations
+                        ELSE articles.locations
+                     END,
+    organizations  = CASE
+                        WHEN COALESCE(jsonb_array_length(EXCLUDED.organizations), 0)
+                           > COALESCE(jsonb_array_length(articles.organizations), 0)
+                        THEN EXCLUDED.organizations
+                        ELSE articles.organizations
+                     END,
+    persons        = CASE
+                        WHEN COALESCE(jsonb_array_length(EXCLUDED.persons), 0)
+                           > COALESCE(jsonb_array_length(articles.persons), 0)
+                        THEN EXCLUDED.persons
+                        ELSE articles.persons
+                     END,
+    all_names      = CASE
+                        WHEN COALESCE(jsonb_array_length(EXCLUDED.all_names), 0)
+                           > COALESCE(jsonb_array_length(articles.all_names), 0)
+                        THEN EXCLUDED.all_names
+                        ELSE articles.all_names
+                     END,
+    tone           = COALESCE(EXCLUDED.tone, articles.tone),
+    first_seen_at  = LEAST(articles.first_seen_at, EXCLUDED.first_seen_at),
+    last_seen_at   = GREATEST(articles.last_seen_at, EXCLUDED.last_seen_at),
+    updated_at     = now()
+"""
 
-    Uses canonical_url as the dedupe key.  On conflict:
-    - merges metadata if the new observation is richer
-    - keeps first_seen_at as the minimum
-    - updates last_seen_at to the new gdelt_timestamp
+
+def _flatten_params(article: dict[str, Any]) -> list[Any]:
+    """Return positional params in the order the INSERT expects.
+
+    first_seen_at and last_seen_at are both seeded from gdelt_timestamp.
     """
+    base = [article.get(col) for col in _UPSERT_COLUMNS]
+    ts = article.get("gdelt_timestamp")
+    base.extend([ts, ts])
+    return base
+
+
+def upsert_articles(
+    articles: list[dict[str, Any]],
+    *,
+    chunk_size: int = 500,
+) -> int:
+    """Batch-upsert articles using a multi-row INSERT per chunk.
+
+    The caller MUST deduplicate by canonical_url before calling; a single
+    statement cannot touch the same conflict target twice (Postgres raises
+    "ON CONFLICT DO UPDATE command cannot affect row a second time").
+
+    Returns the number of rows written.  Raises on database errors — chunks
+    are atomic: a single failing chunk rolls back and aborts the call.
+    """
+    if not articles:
+        return 0
+
     pool = get_pool()
-    with pool.connection() as conn:
-        with conn.cursor(row_factory=dict_row) as cur:
-            cur.execute(
-                """
-                INSERT INTO articles (
-                    gkg_record_id, gdelt_timestamp, url, canonical_url,
-                    domain, source_common_name, canonical_source, title,
-                    themes, locations, organizations, persons, all_names, tone,
-                    first_seen_at, last_seen_at
-                ) VALUES (
-                    %(gkg_record_id)s, %(gdelt_timestamp)s, %(url)s, %(canonical_url)s,
-                    %(domain)s, %(source_common_name)s, %(canonical_source)s, %(title)s,
-                    %(themes)s, %(locations)s, %(organizations)s, %(persons)s,
-                    %(all_names)s, %(tone)s,
-                    %(gdelt_timestamp)s, %(gdelt_timestamp)s
-                )
-                ON CONFLICT (canonical_url) DO UPDATE SET
-                    themes         = CASE
-                                        WHEN COALESCE(jsonb_array_length(EXCLUDED.themes), 0)
-                                           > COALESCE(jsonb_array_length(articles.themes), 0)
-                                        THEN EXCLUDED.themes
-                                        ELSE articles.themes
-                                     END,
-                    locations      = CASE
-                                        WHEN COALESCE(jsonb_array_length(EXCLUDED.locations), 0)
-                                           > COALESCE(jsonb_array_length(articles.locations), 0)
-                                        THEN EXCLUDED.locations
-                                        ELSE articles.locations
-                                     END,
-                    organizations  = CASE
-                                        WHEN COALESCE(jsonb_array_length(EXCLUDED.organizations), 0)
-                                           > COALESCE(jsonb_array_length(articles.organizations), 0)
-                                        THEN EXCLUDED.organizations
-                                        ELSE articles.organizations
-                                     END,
-                    persons        = CASE
-                                        WHEN COALESCE(jsonb_array_length(EXCLUDED.persons), 0)
-                                           > COALESCE(jsonb_array_length(articles.persons), 0)
-                                        THEN EXCLUDED.persons
-                                        ELSE articles.persons
-                                     END,
-                    all_names      = CASE
-                                        WHEN COALESCE(jsonb_array_length(EXCLUDED.all_names), 0)
-                                           > COALESCE(jsonb_array_length(articles.all_names), 0)
-                                        THEN EXCLUDED.all_names
-                                        ELSE articles.all_names
-                                     END,
-                    tone           = COALESCE(EXCLUDED.tone, articles.tone),
-                    first_seen_at  = LEAST(articles.first_seen_at, EXCLUDED.first_seen_at),
-                    last_seen_at   = GREATEST(articles.last_seen_at, EXCLUDED.last_seen_at),
-                    updated_at     = now()
-                RETURNING *
-                """,
-                article,
-            )
-            row = cur.fetchone()
-        conn.commit()
-    return row
+    total_written = 0
+    columns_sql = ", ".join([*_UPSERT_COLUMNS, "first_seen_at", "last_seen_at"])
+
+    for start in range(0, len(articles), chunk_size):
+        chunk = articles[start : start + chunk_size]
+        values_sql = ", ".join([_ROW_PLACEHOLDERS] * len(chunk))
+        params: list[Any] = []
+        for article in chunk:
+            params.extend(_flatten_params(article))
+
+        statement = (
+            f"INSERT INTO articles ({columns_sql}) VALUES {values_sql}"
+            f"{_UPSERT_CONFLICT_CLAUSE}RETURNING id"
+        )
+
+        with pool.connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cur:
+                cur.execute(statement, params)
+                rows = cur.fetchall()
+            conn.commit()
+
+        total_written += len(rows)
+
+    return total_written
+
+
+def upsert_article(article: dict[str, Any]) -> int:
+    """Single-row convenience wrapper around `upsert_articles`."""
+    return upsert_articles([article])
 
 
 def get_article_by_canonical_url(canonical_url: str) -> dict[str, Any] | None:

--- a/src/gdelt_event_pipeline/storage/articles.py
+++ b/src/gdelt_event_pipeline/storage/articles.py
@@ -295,6 +295,7 @@ def update_article_titles(titles: dict[str, str]) -> int:
 
 
 def update_article_embedding(article_id: str, embedding: list[float], model: str) -> None:
+    """Set the embedding for a single article."""
     pool = get_pool()
     with pool.connection() as conn:
         with conn.cursor() as cur:
@@ -307,3 +308,47 @@ def update_article_embedding(article_id: str, embedding: list[float], model: str
                 (embedding, model, article_id),
             )
         conn.commit()
+
+
+def update_article_embeddings(
+    updates: list[tuple[str, list[float]]],
+    model: str,
+    *,
+    chunk_size: int = 500,
+) -> int:
+    """Batch-update embeddings in a single UPDATE ... FROM (VALUES ...) per chunk.
+
+    `updates` is a list of (article_id, vector) pairs.  `model` is the
+    embedding_model name — constant for the batch (it comes from settings).
+
+    Returns the total number of rows updated across all chunks.
+    """
+    if not updates:
+        return 0
+
+    pool = get_pool()
+    total_affected = 0
+
+    for start in range(0, len(updates), chunk_size):
+        chunk = updates[start : start + chunk_size]
+        values_sql = ", ".join(["(%s::uuid, %s::vector)"] * len(chunk))
+        params: list[Any] = [model]
+        for article_id, vector in chunk:
+            params.extend([article_id, vector])
+
+        statement = f"""
+            UPDATE articles
+            SET embedding = v.embedding,
+                embedding_model = %s,
+                updated_at = now()
+            FROM (VALUES {values_sql}) AS v(id, embedding)
+            WHERE articles.id = v.id
+        """
+
+        with pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(statement, params)
+                total_affected += cur.rowcount
+            conn.commit()
+
+    return total_affected

--- a/src/gdelt_event_pipeline/storage/articles.py
+++ b/src/gdelt_event_pipeline/storage/articles.py
@@ -249,7 +249,7 @@ def increment_scrape_attempts(article_ids: list[str]) -> None:
 
 
 def update_article_title(article_id: str, title: str) -> None:
-    """Set the title for an article."""
+    """Set the title for a single article."""
     pool = get_pool()
     with pool.connection() as conn:
         with conn.cursor() as cur:
@@ -262,6 +262,36 @@ def update_article_title(article_id: str, title: str) -> None:
                 (title, article_id),
             )
         conn.commit()
+
+
+def update_article_titles(titles: dict[str, str]) -> int:
+    """Set titles for many articles in a single UPDATE.
+
+    `titles` maps article_id → title.  Returns the number of rows updated.
+    """
+    if not titles:
+        return 0
+
+    pool = get_pool()
+    pairs = list(titles.items())
+    values_sql = ", ".join(["(%s::uuid, %s)"] * len(pairs))
+    params: list[Any] = []
+    for article_id, title in pairs:
+        params.extend([article_id, title])
+
+    statement = f"""
+        UPDATE articles
+        SET title = v.title, updated_at = now()
+        FROM (VALUES {values_sql}) AS v(id, title)
+        WHERE articles.id = v.id
+    """
+
+    with pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(statement, params)
+            affected = cur.rowcount
+        conn.commit()
+    return affected
 
 
 def update_article_embedding(article_id: str, embedding: list[float], model: str) -> None:

--- a/src/gdelt_event_pipeline/storage/clusters.py
+++ b/src/gdelt_event_pipeline/storage/clusters.py
@@ -167,22 +167,48 @@ def get_cluster_articles(cluster_id: str) -> list[dict[str, Any]]:
 
 
 def get_cluster_entity_sample(cluster_id: str, *, limit: int = 5) -> list[dict[str, Any]]:
-    """Fetch entity fields from a cluster's most recent articles."""
+    """Fetch entity fields from a single cluster's most recent articles."""
+    return get_cluster_entity_samples([cluster_id], limit=limit).get(cluster_id, [])
+
+
+def get_cluster_entity_samples(
+    cluster_ids: list[str], *, limit: int = 5
+) -> dict[str, list[dict[str, Any]]]:
+    """Fetch entity samples for several clusters in a single query.
+
+    Returns a dict mapping cluster_id → list of entity rows (locations,
+    persons, organizations) from each cluster's `limit` most recent articles.
+    Missing clusters are absent from the dict (caller should default to []).
+
+    Uses LATERAL to apply the per-cluster ORDER BY / LIMIT without a full
+    scan, so one RTT replaces up to N per-cluster queries.
+    """
+    if not cluster_ids:
+        return {}
     pool = get_pool()
+    results: dict[str, list[dict[str, Any]]] = {cid: [] for cid in cluster_ids}
     with pool.connection() as conn:
         with conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 """
-                SELECT a.locations, a.persons, a.organizations
-                FROM articles a
-                JOIN cluster_memberships cm ON cm.article_id = a.id
-                WHERE cm.cluster_id = %s
-                ORDER BY a.gdelt_timestamp DESC
-                LIMIT %s
+                SELECT c.id::text AS cluster_id,
+                       s.locations, s.persons, s.organizations
+                FROM unnest(%s::uuid[]) AS c(id)
+                CROSS JOIN LATERAL (
+                    SELECT a.locations, a.persons, a.organizations
+                    FROM articles a
+                    JOIN cluster_memberships cm ON cm.article_id = a.id
+                    WHERE cm.cluster_id = c.id
+                    ORDER BY a.gdelt_timestamp DESC
+                    LIMIT %s
+                ) s
                 """,
-                (cluster_id, limit),
+                (cluster_ids, limit),
             )
-            return cur.fetchall()
+            for row in cur.fetchall():
+                cid = row.pop("cluster_id")
+                results[cid].append(row)
+    return results
 
 
 def update_cluster_centroid(cluster_id: str, centroid: list[float]) -> None:

--- a/tests/clustering/test_assign.py
+++ b/tests/clustering/test_assign.py
@@ -36,13 +36,13 @@ def _make_cluster(cluster_id="clust-1", cosine_distance=0.1, article_count=5, ce
 
 @patch("gdelt_event_pipeline.clustering.assign.update_cluster_centroid")
 @patch("gdelt_event_pipeline.clustering.assign.assign_article_to_cluster")
-@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_sample")
+@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_samples")
 @patch("gdelt_event_pipeline.clustering.assign.find_nearest_cluster")
 def test_assigns_to_existing_above_threshold(
-    mock_find, mock_sample, mock_assign, mock_update_centroid
+    mock_find, mock_samples, mock_assign, mock_update_centroid
 ):
     mock_find.return_value = [_make_cluster(cosine_distance=0.1)]
-    mock_sample.return_value = []  # no entity data
+    mock_samples.return_value = {}  # no entity data for any candidate
 
     result = assign_article(_make_article())
 
@@ -54,11 +54,11 @@ def test_assigns_to_existing_above_threshold(
 
 @patch("gdelt_event_pipeline.clustering.assign.update_cluster_centroid")
 @patch("gdelt_event_pipeline.clustering.assign.assign_article_to_cluster")
-@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_sample")
+@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_samples")
 @patch("gdelt_event_pipeline.clustering.assign.find_nearest_cluster")
-def test_max_age_hours_forwarded_to_find(mock_find, mock_sample, mock_assign, mock_update):
+def test_max_age_hours_forwarded_to_find(mock_find, mock_samples, mock_assign, mock_update):
     mock_find.return_value = [_make_cluster(cosine_distance=0.1)]
-    mock_sample.return_value = []
+    mock_samples.return_value = {}
 
     assign_article(_make_article(), max_age_hours=48)
 
@@ -67,11 +67,11 @@ def test_max_age_hours_forwarded_to_find(mock_find, mock_sample, mock_assign, mo
 
 @patch("gdelt_event_pipeline.clustering.assign.assign_article_to_cluster")
 @patch("gdelt_event_pipeline.clustering.assign.create_cluster")
-@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_sample")
+@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_samples")
 @patch("gdelt_event_pipeline.clustering.assign.find_nearest_cluster")
-def test_creates_new_cluster_below_threshold(mock_find, mock_sample, mock_create, mock_assign):
+def test_creates_new_cluster_below_threshold(mock_find, mock_samples, mock_create, mock_assign):
     mock_find.return_value = [_make_cluster(cosine_distance=0.5)]
-    mock_sample.return_value = []
+    mock_samples.return_value = {}
     mock_create.return_value = {"id": "new-clust"}
 
     result = assign_article(_make_article())
@@ -95,22 +95,24 @@ def test_creates_new_cluster_when_none_exist(mock_find, mock_create, mock_assign
 
 @patch("gdelt_event_pipeline.clustering.assign.update_cluster_centroid")
 @patch("gdelt_event_pipeline.clustering.assign.assign_article_to_cluster")
-@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_sample")
+@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_samples")
 @patch("gdelt_event_pipeline.clustering.assign.find_nearest_cluster")
-def test_entity_overlap_boosts_borderline_match(mock_find, mock_sample, mock_assign, mock_update):
+def test_entity_overlap_boosts_borderline_match(mock_find, mock_samples, mock_assign, mock_update):
     # cosine similarity = 0.68 (below 0.70 threshold)
     mock_find.return_value = [_make_cluster(cosine_distance=0.32)]
 
     # But strong entity overlap should push it above threshold
     import json
 
-    mock_sample.return_value = [
-        {
-            "locations": json.dumps([{"name": "Berlin"}]),
-            "persons": json.dumps(["Scholz"]),
-            "organizations": None,
-        }
-    ]
+    mock_samples.return_value = {
+        "clust-1": [
+            {
+                "locations": json.dumps([{"name": "Berlin"}]),
+                "persons": json.dumps(["Scholz"]),
+                "organizations": None,
+            }
+        ]
+    }
 
     article = _make_article(
         locations=json.dumps([{"name": "Berlin"}]),
@@ -125,9 +127,9 @@ def test_entity_overlap_boosts_borderline_match(mock_find, mock_sample, mock_ass
 
 @patch("gdelt_event_pipeline.clustering.assign.assign_article_to_cluster")
 @patch("gdelt_event_pipeline.clustering.assign.create_cluster")
-@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_sample")
+@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_samples")
 @patch("gdelt_event_pipeline.clustering.assign.find_nearest_cluster")
-def test_picks_best_candidate_across_multiple(mock_find, mock_sample, mock_create, mock_assign):
+def test_picks_best_candidate_across_multiple(mock_find, mock_samples, mock_create, mock_assign):
     # Two candidates: first has closer cosine but no entity match,
     # second has slightly worse cosine but strong entity match
     mock_find.return_value = [
@@ -137,18 +139,22 @@ def test_picks_best_candidate_across_multiple(mock_find, mock_sample, mock_creat
 
     import json
 
-    mock_sample.side_effect = [
-        # close-no-entity: no matching entities
-        [{"locations": json.dumps([{"name": "Tokyo"}]), "persons": None, "organizations": None}],
-        # far-with-entity: matching entities
-        [
+    mock_samples.return_value = {
+        "close-no-entity": [
+            {
+                "locations": json.dumps([{"name": "Tokyo"}]),
+                "persons": None,
+                "organizations": None,
+            }
+        ],
+        "far-with-entity": [
             {
                 "locations": json.dumps([{"name": "Berlin"}]),
                 "persons": json.dumps(["Scholz"]),
                 "organizations": None,
             }
         ],
-    ]
+    }
 
     article = _make_article(
         locations=json.dumps([{"name": "Berlin"}]),
@@ -164,14 +170,14 @@ def test_picks_best_candidate_across_multiple(mock_find, mock_sample, mock_creat
 
 @patch("gdelt_event_pipeline.clustering.assign.update_cluster_centroid")
 @patch("gdelt_event_pipeline.clustering.assign.assign_article_to_cluster")
-@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_sample")
+@patch("gdelt_event_pipeline.clustering.assign.get_cluster_entity_samples")
 @patch("gdelt_event_pipeline.clustering.assign.find_nearest_cluster")
-def test_centroid_updated_on_assignment(mock_find, mock_sample, mock_assign, mock_update_centroid):
+def test_centroid_updated_on_assignment(mock_find, mock_samples, mock_assign, mock_update_centroid):
     centroid = [1.0] * 384
     mock_find.return_value = [
         _make_cluster(cosine_distance=0.05, article_count=1, centroid=centroid)
     ]
-    mock_sample.return_value = []
+    mock_samples.return_value = {}
 
     article = _make_article(embedding=[0.0] * 384)
     assign_article(article)

--- a/tests/embeddings/test_pipeline.py
+++ b/tests/embeddings/test_pipeline.py
@@ -18,8 +18,13 @@ def _make_article(article_id, title, themes=None):
     }
 
 
+def _batch_update_mock(updates, model, **kwargs):
+    """Mimic update_article_embeddings: return the row count it wrote."""
+    return len(updates)
+
+
 class TestRunEmbedding:
-    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embedding")
+    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embeddings")
     @patch("gdelt_event_pipeline.embeddings.pipeline.embed_texts")
     @patch("gdelt_event_pipeline.embeddings.pipeline.get_unembedded_articles")
     def test_basic_flow(self, mock_get, mock_embed, mock_update):
@@ -28,6 +33,7 @@ class TestRunEmbedding:
             _make_article("id-2", "Stock market crash"),
         ]
         mock_embed.return_value = [[0.1] * 384, [0.2] * 384]
+        mock_update.side_effect = _batch_update_mock
 
         settings = EmbeddingSettings()
         result = run_embedding(settings, limit=10)
@@ -38,9 +44,10 @@ class TestRunEmbedding:
         assert result.articles_failed == 0
 
         mock_embed.assert_called_once()
-        assert mock_update.call_count == 2
+        # Both embeddings go in a single batched UPDATE now
+        assert mock_update.call_count == 1
 
-    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embedding")
+    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embeddings")
     @patch("gdelt_event_pipeline.embeddings.pipeline.embed_texts")
     @patch("gdelt_event_pipeline.embeddings.pipeline.get_unembedded_articles")
     def test_no_articles(self, mock_get, mock_embed, mock_update):
@@ -52,7 +59,7 @@ class TestRunEmbedding:
         mock_embed.assert_not_called()
         mock_update.assert_not_called()
 
-    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embedding")
+    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embeddings")
     @patch("gdelt_event_pipeline.embeddings.pipeline.embed_texts")
     @patch("gdelt_event_pipeline.embeddings.pipeline.get_unembedded_articles")
     def test_skips_empty_text(self, mock_get, mock_embed, mock_update):
@@ -61,6 +68,7 @@ class TestRunEmbedding:
             _make_article("id-2", "Valid title"),
         ]
         mock_embed.return_value = [[0.1] * 384]
+        mock_update.side_effect = _batch_update_mock
 
         result = run_embedding()
         assert result.articles_skipped == 1
@@ -71,7 +79,7 @@ class TestRunEmbedding:
         assert len(texts_arg) == 1
         assert "Valid title" in texts_arg[0]
 
-    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embedding")
+    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embeddings")
     @patch("gdelt_event_pipeline.embeddings.pipeline.embed_texts")
     @patch("gdelt_event_pipeline.embeddings.pipeline.get_unembedded_articles")
     def test_skips_no_title_even_with_metadata(self, mock_get, mock_embed, mock_update):
@@ -81,12 +89,13 @@ class TestRunEmbedding:
             _make_article("id-2", "Valid title"),
         ]
         mock_embed.return_value = [[0.1] * 384]
+        mock_update.side_effect = _batch_update_mock
 
         result = run_embedding()
         assert result.articles_skipped == 1
         assert result.articles_embedded == 1
 
-    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embedding")
+    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embeddings")
     @patch("gdelt_event_pipeline.embeddings.pipeline.embed_texts")
     @patch("gdelt_event_pipeline.embeddings.pipeline.get_unembedded_articles")
     def test_db_failure_counted(self, mock_get, mock_embed, mock_update):
@@ -95,15 +104,17 @@ class TestRunEmbedding:
         mock_update.side_effect = RuntimeError("DB error")
 
         result = run_embedding()
+        # Whole batch is counted as failed when the single UPDATE raises
         assert result.articles_failed == 1
         assert result.articles_embedded == 0
 
-    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embedding")
+    @patch("gdelt_event_pipeline.embeddings.pipeline.update_article_embeddings")
     @patch("gdelt_event_pipeline.embeddings.pipeline.embed_texts")
     @patch("gdelt_event_pipeline.embeddings.pipeline.get_unembedded_articles")
     def test_passes_settings_to_embed(self, mock_get, mock_embed, mock_update):
         mock_get.return_value = [_make_article("id-1", "Title")]
         mock_embed.return_value = [[0.1] * 384]
+        mock_update.side_effect = _batch_update_mock
 
         settings = EmbeddingSettings(
             model_name="custom-model",
@@ -117,4 +128,4 @@ class TestRunEmbedding:
             model_name="custom-model",
             batch_size=16,
         )
-        mock_update.assert_called_once_with("id-1", [0.1] * 384, "custom-model")
+        mock_update.assert_called_once_with([("id-1", [0.1] * 384)], "custom-model")

--- a/tests/ingestion/test_pipeline.py
+++ b/tests/ingestion/test_pipeline.py
@@ -20,14 +20,15 @@ def _make_gkg_row(record_id="20260315120000-1", url="http://example.com/article"
 
 class TestRunIngestion:
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_basic_flow(self, mock_download, mock_upsert, mock_update_state):
         mock_download.return_value = [
             _make_gkg_row("rec-1", "http://a.com/1"),
             _make_gkg_row("rec-2", "http://b.com/2"),
         ]
-        mock_upsert.return_value = {"id": "some-uuid"}
+        # Batch upsert returns the number of rows it wrote.
+        mock_upsert.side_effect = lambda articles, **kwargs: len(articles)
 
         result = run_ingestion(gkg_url="http://example.com/test.gkg.csv.zip")
 
@@ -35,11 +36,12 @@ class TestRunIngestion:
         assert result.rows_normalized == 2
         assert result.rows_upserted == 2
         assert result.rows_failed == 0
-        assert mock_upsert.call_count == 2
+        # Both articles go in a single batch now
+        assert mock_upsert.call_count == 1
         mock_update_state.assert_called_once()
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_dry_run_skips_db(self, mock_download, mock_upsert, mock_update_state):
         mock_download.return_value = [_make_gkg_row()]
@@ -51,7 +53,7 @@ class TestRunIngestion:
         mock_update_state.assert_not_called()
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_skips_unnormalizable_rows(self, mock_download, mock_upsert, mock_update_state):
         # Row too short → normalize_row returns None
@@ -64,7 +66,7 @@ class TestRunIngestion:
         mock_upsert.assert_not_called()
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_deduplicates_within_batch(self, mock_download, mock_upsert, mock_update_state):
         # Same URL appears twice
@@ -72,7 +74,7 @@ class TestRunIngestion:
             _make_gkg_row("rec-1", "http://a.com/article"),
             _make_gkg_row("rec-2", "http://a.com/article"),
         ]
-        mock_upsert.return_value = {"id": "some-uuid"}
+        mock_upsert.side_effect = lambda articles, **kwargs: len(articles)
 
         result = run_ingestion(gkg_url="http://example.com/test.gkg.csv.zip")
 
@@ -82,7 +84,7 @@ class TestRunIngestion:
         assert mock_upsert.call_count == 1
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_upsert_failure_counted(self, mock_download, mock_upsert, mock_update_state):
         mock_download.return_value = [_make_gkg_row()]
@@ -97,7 +99,7 @@ class TestRunIngestion:
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.get_latest_gkg_url")
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_resolves_url_when_not_provided(
         self, mock_download, mock_upsert, mock_update_state, mock_get_url
@@ -111,7 +113,7 @@ class TestRunIngestion:
         mock_download.assert_called_once_with("http://example.com/latest.gkg.csv.zip", timeout=30)
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.update_pipeline_state")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_article")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.upsert_articles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.download_and_parse_gkg")
     def test_empty_fetch_no_checkpoint(self, mock_download, mock_upsert, mock_update_state):
         mock_download.return_value = []

--- a/tests/ingestion/test_pipeline.py
+++ b/tests/ingestion/test_pipeline.py
@@ -129,7 +129,7 @@ class TestRunIngestion:
 
 class TestRunTitleScraping:
     @patch("gdelt_event_pipeline.ingestion.pipeline.increment_scrape_attempts")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.update_article_title")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.update_article_titles")
     @patch("gdelt_event_pipeline.ingestion.scraper.scrape_titles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.get_untitled_articles")
     def test_scrapes_and_updates(self, mock_get, mock_scrape, mock_update, mock_increment):
@@ -143,12 +143,12 @@ class TestRunTitleScraping:
 
         assert attempted == 2
         assert succeeded == 1
-        mock_update.assert_called_once_with("id-1", "Title A")
+        mock_update.assert_called_once_with({"id-1": "Title A"})
         # All attempted articles get their counter bumped, not just successes
         mock_increment.assert_called_once_with(["id-1", "id-2"])
 
     @patch("gdelt_event_pipeline.ingestion.pipeline.increment_scrape_attempts")
-    @patch("gdelt_event_pipeline.ingestion.pipeline.update_article_title")
+    @patch("gdelt_event_pipeline.ingestion.pipeline.update_article_titles")
     @patch("gdelt_event_pipeline.ingestion.scraper.scrape_titles")
     @patch("gdelt_event_pipeline.ingestion.pipeline.get_untitled_articles")
     def test_no_untitled_articles(self, mock_get, mock_scrape, mock_update, mock_increment):


### PR DESCRIPTION
## Summary

The pipeline was doing one-row-at-a-time SQL against Postgres in four hot loops — ingestion upserts, title updates, embedding updates, and clustering's per-candidate entity sample lookup. Against a remote DB (Neon us-east from EU, ~150 ms RTT) each row was paying 1-2 network round trips, so cycles that should take seconds were taking minutes with CPU idle. This PR collapses each of those loops into a single (or chunked) statement.

Scoring / matching / merge semantics are unchanged — only the DB access pattern moves.

## What changed, by stage

### Ingestion upserts (`9159ad4`)

- Replaced per-row loop with chunked multi-row `INSERT ... VALUES (...), (...)` statements (500 rows/chunk), reusing the same `ON CONFLICT DO UPDATE` merge clause
- In-memory dedupe pass required up front: a single INSERT can't touch the same `ON CONFLICT` target twice
- New `upsert_articles(list, *, chunk_size=500)`; `upsert_article` (singular) kept as a thin wrapper
- Extracted the ON CONFLICT clause and column list into module-level constants so the batch and single-row paths stay in sync

### Title scraping (`e2d3925`)

- New `update_article_titles(dict)` does one `UPDATE ... FROM (VALUES ...)` for all `id → title` pairs
- `run_title_scraping` calls it once instead of looping
- Bumped default `max_workers` from 8 → 32 on the HTTP thread pool (I/O-bound, CPU idle)

### Embeddings (`02e2f1a`)

- New `update_article_embeddings(list[(id, vector)], model)` builds one `UPDATE ... SET embedding = v.embedding FROM (VALUES ...)` per chunk, reusing psycopg3's `list → float8[]` adapter plus pgvector's implicit cast
- `embedding_model` is parameterized once outside the VALUES since it's constant for a cycle
- `articles_embedded` now reflects the UPDATE rowcount; a failing batch is counted wholesale against `articles_failed`

### Clustering (`c7ea1de`)

- New `get_cluster_entity_samples(list[str])` fetches entity samples for every candidate cluster in a single query using `unnest(...) CROSS JOIN LATERAL (SELECT ... LIMIT %s)` — each cluster still gets its own ordered LIMIT scan, they just share one RTT
- `assign_article` fetches all candidate samples up front and looks them up in-process, so per-article RTTs on the existing-cluster path go 8 → 4

## Expected impact on a 15-minute cycle against Neon us-east from EU

| Stage | Before | After |
|---|---|---|
| Ingest 1200-row GKG batch | 1200 × 2 RTTs ≈ 6 min | ~3 chunks × 1 RTT ≈ 1 s |
| Title updates (200 successes) | 200 × 1 RTT ≈ 30 s | 1 statement |
| Embedding store (500 articles) | 500 × 1 RTT ≈ 1.25 min | 1 statement |
| Clustering entity samples | 5 RTTs × N articles | 1 RTT × N articles |

## API changes

- `upsert_articles`, `update_article_titles`, `update_article_embeddings`, `get_cluster_entity_samples` are new
- Singular wrappers (`upsert_article`, `update_article_title`, `update_article_embedding`, `get_cluster_entity_sample`) are retained for API stability, though the pipeline no longer uses them
- `run_title_scraping` default `max_workers`: 8 → 32

## Test plan

- [x] `uv run pytest` — 212 passed
- [x] `uv run ruff check .` — clean
- [x] Live-tested each batch step against Neon: ingestion, title updates, embedding updates verified ok by the author before their respective commits landed
- [ ] Run a full pipeline cycle and confirm the whole cycle fits well inside 15 min against Neon
- [ ] Re-ingest a GKG file that overlaps a prior batch and verify ON CONFLICT merge semantics are preserved (jsonb arrays merged, not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)